### PR TITLE
Fix the rename to digitalocean_client in the Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
 
 Then import the package:
 ```python
-import openapi_client
+import digitalocean_client
 ```
 
 ### Setuptools
@@ -406,7 +406,7 @@ python setup.py install --user
 
 Then import the package:
 ```python
-import openapi_client
+import digitalocean_client
 ```
 
 ## Getting Started
@@ -416,15 +416,15 @@ Please follow the [installation procedure](#installation--usage) and then run th
 ```python
 
 import time
-import openapi_client
+import digitalocean_client
 from pprint import pprint
-from openapi_client.api import 1_click_applications_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response200 import InlineResponse200
-from openapi_client.model.model1_click_create import Model1ClickCreate
+from digitalocean_client.api import 1_click_applications_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response200 import InlineResponse200
+from digitalocean_client.model.model1_click_create import Model1ClickCreate
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -434,13 +434,13 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = 1_click_applications_api.ClickApplicationsApi(api_client)
     model1_click_create = Model1ClickCreate(
@@ -452,7 +452,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Install Kubernetes 1-Click Applications
         api_response = api_instance.install_kubernetes(model1_click_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ClickApplicationsApi->install_kubernetes: %s\n" % e)
 ```
 
@@ -1044,21 +1044,21 @@ api-engineering@digitalocean.com
 
 
 ## Notes for Large OpenAPI documents
-If the OpenAPI document is large, imports in openapi_client.apis and openapi_client.models may fail with a
+If the OpenAPI document is large, imports in digitalocean_client.apis and digitalocean_client.models may fail with a
 RecursionError indicating the maximum recursion limit has been exceeded. In that case, there are a couple of solutions:
 
 Solution 1:
 Use specific imports for apis and models like:
-- `from openapi_client.api.default_api import DefaultApi`
-- `from openapi_client.model.pet import Pet`
+- `from digitalocean_client.api.default_api import DefaultApi`
+- `from digitalocean_client.model.pet import Pet`
 
 Solution 2:
 Before importing the package, adjust the maximum recursion limit as shown below:
 ```
 import sys
 sys.setrecursionlimit(1500)
-import openapi_client
-from openapi_client.apis import *
-from openapi_client.models import *
+import digitalocean_client
+from digitalocean_client.apis import *
+from digitalocean_client.models import *
 ```
 

--- a/docs/1ClickApplicationsApi.md
+++ b/docs/1ClickApplicationsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ClickApplicationsApi
+# digitalocean_client.ClickApplicationsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -21,15 +21,15 @@ To install a Kubernetes 1-Click application on a cluster, send a POST request to
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import 1_click_applications_api
-from openapi_client.model.model1_click_create import Model1ClickCreate
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response200 import InlineResponse200
+import digitalocean_client
+from digitalocean_client.api import 1_click_applications_api
+from digitalocean_client.model.model1_click_create import Model1ClickCreate
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response200 import InlineResponse200
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -39,12 +39,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = 1_click_applications_api.ClickApplicationsApi(api_client)
     model1_click_create = Model1ClickCreate(
@@ -57,7 +57,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Install Kubernetes 1-Click Applications
         api_response = api_instance.install_kubernetes(model1_click_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ClickApplicationsApi->install_kubernetes: %s\n" % e)
 ```
 
@@ -107,13 +107,13 @@ To list all available 1-Click applications, send a GET request to `/v2/1-clicks`
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import 1_click_applications_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import 1_click_applications_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -123,12 +123,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = 1_click_applications_api.ClickApplicationsApi(api_client)
     type = "kubernetes" # str | Restrict results to a certain type of 1-Click. (optional)
@@ -139,7 +139,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List 1-Click Applications
         api_response = api_instance.list(type=type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ClickApplicationsApi->list: %s\n" % e)
 ```
 

--- a/docs/AccountApi.md
+++ b/docs/AccountApi.md
@@ -1,4 +1,4 @@
-# openapi_client.AccountApi
+# digitalocean_client.AccountApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -20,13 +20,13 @@ To show information about the current user account, send a GET request to `/v2/a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import account_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import account_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -36,12 +36,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = account_api.AccountApi(api_client)
 
@@ -50,7 +50,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get User Information
         api_response = api_instance.get_user_information()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AccountApi->get_user_information: %s\n" % e)
 ```
 

--- a/docs/ActionsApi.md
+++ b/docs/ActionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ActionsApi
+# digitalocean_client.ActionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -21,13 +21,13 @@ To retrieve a specific action object, send a GET request to `/v2/actions/$ACTION
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -37,12 +37,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = actions_api.ActionsApi(api_client)
     action_id = 36804636 # int | A unique numeric ID that can be used to identify and reference an action.
@@ -52,7 +52,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Action
         api_response = api_instance.get_action(action_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ActionsApi->get_action: %s\n" % e)
 ```
 
@@ -103,13 +103,13 @@ This will be the entire list of actions taken on your account, so it will be qui
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -119,12 +119,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = actions_api.ActionsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -136,7 +136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Actions
         api_response = api_instance.list_all_actions(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ActionsApi->list_all_actions: %s\n" % e)
 ```
 

--- a/docs/AppsApi.md
+++ b/docs/AppsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.AppsApi
+# digitalocean_client.AppsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -38,15 +38,15 @@ Updates the emails and slack webhook destinations for app alerts. Emails must be
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_assign_app_alert_destinations_request import AppsAssignAppAlertDestinationsRequest
-from openapi_client.model.apps_alert_response import AppsAlertResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_assign_app_alert_destinations_request import AppsAssignAppAlertDestinationsRequest
+from digitalocean_client.model.apps_alert_response import AppsAlertResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -56,12 +56,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -81,7 +81,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update destinations for alerts
         api_response = api_instance.assign_alert_destinations(app_id, alert_id, apps_assign_app_alert_destinations_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->assign_alert_destinations: %s\n" % e)
 ```
 
@@ -134,15 +134,15 @@ Create a new app by submitting an app specification. For documentation on app sp
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.app_response import AppResponse
-from openapi_client.model.error import Error
-from openapi_client.model.apps_create_app_request import AppsCreateAppRequest
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.app_response import AppResponse
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_create_app_request import AppsCreateAppRequest
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -152,12 +152,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     apps_create_app_request = AppsCreateAppRequest(
@@ -203,7 +203,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New App
         api_response = api_instance.create_app(apps_create_app_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->create_app: %s\n" % e)
 ```
 
@@ -253,15 +253,15 @@ Creating an app deployment will pull the latest changes from your repository and
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_create_deployment_request import AppsCreateDeploymentRequest
-from openapi_client.model.error import Error
-from openapi_client.model.apps_deployment_response import AppsDeploymentResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_create_deployment_request import AppsCreateDeploymentRequest
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_deployment_response import AppsDeploymentResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -271,12 +271,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -289,7 +289,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create an App Deployment
         api_response = api_instance.create_deployment(app_id, apps_create_deployment_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->create_deployment: %s\n" % e)
 ```
 
@@ -341,14 +341,14 @@ Delete an existing app. Once deleted, all active deployments will be permanently
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_delete_app_response import AppsDeleteAppResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_delete_app_response import AppsDeleteAppResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -358,12 +358,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The ID of the app
@@ -373,7 +373,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Delete an App
         api_response = api_instance.delete_app(id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->delete_app: %s\n" % e)
 ```
 
@@ -424,14 +424,14 @@ Retrieve details about an existing app by either its ID or name. To retrieve an 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.app_response import AppResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.app_response import AppResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -441,12 +441,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The ID of the app
@@ -457,7 +457,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing App
         api_response = api_instance.get_app(id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_app: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -466,7 +466,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing App
         api_response = api_instance.get_app(id, name=name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_app: %s\n" % e)
 ```
 
@@ -518,14 +518,14 @@ Retrieve information about an app deployment.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_deployment_response import AppsDeploymentResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_deployment_response import AppsDeploymentResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -535,12 +535,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -551,7 +551,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an App Deployment
         api_response = api_instance.get_deployment(app_id, deployment_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_deployment: %s\n" % e)
 ```
 
@@ -603,14 +603,14 @@ Retrieve information about a specific instance size for `service`, `worker`, and
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_get_instance_size_response import AppsGetInstanceSizeResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_get_instance_size_response import AppsGetInstanceSizeResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -620,12 +620,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     slug = "basic-xxs" # str | The slug of the instance size
@@ -635,7 +635,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Instance Size
         api_response = api_instance.get_instance_size(slug)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_instance_size: %s\n" % e)
 ```
 
@@ -686,14 +686,14 @@ Retrieve the logs of a past, in-progress, or active deployment. If a component n
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_get_logs_response import AppsGetLogsResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_get_logs_response import AppsGetLogsResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -703,12 +703,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -722,7 +722,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Deployment Logs
         api_response = api_instance.get_logs(app_id, deployment_id, component_name, )
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_logs: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -731,7 +731,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Deployment Logs
         api_response = api_instance.get_logs(app_id, deployment_id, component_name, follow=follow, pod_connection_timeout=pod_connection_timeout)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_logs: %s\n" % e)
 ```
 
@@ -787,14 +787,14 @@ Retrieve the logs of a past, in-progress, or active deployment. If a component n
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_get_logs_response import AppsGetLogsResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_get_logs_response import AppsGetLogsResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -804,12 +804,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -822,7 +822,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Aggregate Deployment Logs
         api_response = api_instance.get_logs_aggregate(app_id, deployment_id, )
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_logs_aggregate: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -831,7 +831,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Aggregate Deployment Logs
         api_response = api_instance.get_logs_aggregate(app_id, deployment_id, follow=follow, pod_connection_timeout=pod_connection_timeout)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_logs_aggregate: %s\n" % e)
 ```
 
@@ -886,14 +886,14 @@ Retrieve information about a specific app tier.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_get_tier_response import AppsGetTierResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_get_tier_response import AppsGetTierResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -903,12 +903,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     slug = "basic" # str | The slug of the tier
@@ -918,7 +918,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an App Tier
         api_response = api_instance.get_tier(slug)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->get_tier: %s\n" % e)
 ```
 
@@ -969,14 +969,14 @@ List alerts associated to the app and any components. This includes configuratio
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_list_alerts_response import AppsListAlertsResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_list_alerts_response import AppsListAlertsResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -986,12 +986,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -1001,7 +1001,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List all app alerts
         api_response = api_instance.list_alerts(app_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_alerts: %s\n" % e)
 ```
 
@@ -1052,14 +1052,14 @@ List all apps on your account. Information about the current active deployment a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_response import AppsResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_response import AppsResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1069,12 +1069,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     page = 1 # int | Which 'page' of paginated results to return. (optional) if omitted the server will use the default value of 1
@@ -1086,7 +1086,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Apps
         api_response = api_instance.list_apps(page=page, per_page=per_page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_apps: %s\n" % e)
 ```
 
@@ -1137,14 +1137,14 @@ List all deployments of an app.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_deployments_response import AppsDeploymentsResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_deployments_response import AppsDeploymentsResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1154,12 +1154,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -1171,7 +1171,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List App Deployments
         api_response = api_instance.list_deployments(app_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_deployments: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1180,7 +1180,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List App Deployments
         api_response = api_instance.list_deployments(app_id, page=page, per_page=per_page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_deployments: %s\n" % e)
 ```
 
@@ -1233,14 +1233,14 @@ List all instance sizes for `service`, `worker`, and `job` components.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_list_instance_sizes_response import AppsListInstanceSizesResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_list_instance_sizes_response import AppsListInstanceSizesResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1250,12 +1250,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
 
@@ -1264,7 +1264,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Instance Sizes
         api_response = api_instance.list_instance_sizes()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_instance_sizes: %s\n" % e)
 ```
 
@@ -1311,14 +1311,14 @@ List all regions supported by App Platform.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_list_regions_response import AppsListRegionsResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_list_regions_response import AppsListRegionsResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1328,12 +1328,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
 
@@ -1342,7 +1342,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List App Regions
         api_response = api_instance.list_regions()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_regions: %s\n" % e)
 ```
 
@@ -1389,14 +1389,14 @@ List all app tiers.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_list_tiers_response import AppsListTiersResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_list_tiers_response import AppsListTiersResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1406,12 +1406,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
 
@@ -1420,7 +1420,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List App Tiers
         api_response = api_instance.list_tiers()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->list_tiers: %s\n" % e)
 ```
 
@@ -1467,14 +1467,14 @@ Immediately cancel an in-progress deployment.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.error import Error
-from openapi_client.model.apps_deployment_response import AppsDeploymentResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.apps_deployment_response import AppsDeploymentResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1484,12 +1484,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The app ID
@@ -1500,7 +1500,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Cancel a Deployment
         api_response = api_instance.post_cancel_deployment(app_id, deployment_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->post_cancel_deployment: %s\n" % e)
 ```
 
@@ -1552,15 +1552,15 @@ Update an existing app by submitting a new app specification. For documentation 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.apps_update_app_request import AppsUpdateAppRequest
-from openapi_client.model.app_response import AppResponse
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.apps_update_app_request import AppsUpdateAppRequest
+from digitalocean_client.model.app_response import AppResponse
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1570,12 +1570,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     id = "4f6c71e2-1e90-4762-9fee-6cc4a0a9f2cf" # str | The ID of the app
@@ -1622,7 +1622,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update an App
         api_response = api_instance.update_app(id, apps_update_app_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->update_app: %s\n" % e)
 ```
 
@@ -1674,15 +1674,15 @@ To propose and validate a spec for a new or existing app, send a PUT request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import apps_api
-from openapi_client.model.app_propose import AppPropose
-from openapi_client.model.error import Error
-from openapi_client.model.app_propose_response import AppProposeResponse
+import digitalocean_client
+from digitalocean_client.api import apps_api
+from digitalocean_client.model.app_propose import AppPropose
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.app_propose_response import AppProposeResponse
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1692,12 +1692,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = apps_api.AppsApi(api_client)
     app_propose = AppPropose(
@@ -1744,7 +1744,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Propose an App Spec
         api_response = api_instance.validate_app_spec(app_propose)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling AppsApi->validate_app_spec: %s\n" % e)
 ```
 

--- a/docs/BillingApi.md
+++ b/docs/BillingApi.md
@@ -1,4 +1,4 @@
-# openapi_client.BillingApi
+# digitalocean_client.BillingApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -26,14 +26,14 @@ To retrieve the balances on a customer's account, send a GET request to `/v2/cus
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.balance import Balance
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.balance import Balance
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -43,12 +43,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
 
@@ -57,7 +57,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Customer Balance
         api_response = api_instance.get_customer_balance()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->get_customer_balance: %s\n" % e)
 ```
 
@@ -105,13 +105,13 @@ To retrieve the invoice items for an invoice, send a GET request to `/v2/custome
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -121,12 +121,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
     invoice_uuid = "22737513-0ea7-4206-8ceb-98a575af7681" # str | UUID of the invoice
@@ -136,7 +136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Invoice by UUID
         api_response = api_instance.get_invoice_by_uuid(invoice_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->get_invoice_by_uuid: %s\n" % e)
 ```
 
@@ -187,13 +187,13 @@ To retrieve a CSV for an invoice, send a GET request to `/v2/customers/my/invoic
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -203,12 +203,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
     invoice_uuid = "22737513-0ea7-4206-8ceb-98a575af7681" # str | UUID of the invoice
@@ -218,7 +218,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Invoice CSV by UUID
         api_response = api_instance.get_invoice_csv_by_uuid(invoice_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->get_invoice_csv_by_uuid: %s\n" % e)
 ```
 
@@ -269,13 +269,13 @@ To retrieve a PDF for an invoice, send a GET request to `/v2/customers/my/invoic
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -285,12 +285,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
     invoice_uuid = "22737513-0ea7-4206-8ceb-98a575af7681" # str | UUID of the invoice
@@ -300,7 +300,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Invoice PDF by UUID
         api_response = api_instance.get_invoice_pdf_by_uuid(invoice_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->get_invoice_pdf_by_uuid: %s\n" % e)
 ```
 
@@ -351,14 +351,14 @@ To retrieve a summary for an invoice, send a GET request to `/v2/customers/my/in
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.invoice_summary import InvoiceSummary
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.invoice_summary import InvoiceSummary
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -368,12 +368,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
     invoice_uuid = "22737513-0ea7-4206-8ceb-98a575af7681" # str | UUID of the invoice
@@ -383,7 +383,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Invoice Summary by UUID
         api_response = api_instance.get_invoice_summary_by_uuid(invoice_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->get_invoice_summary_by_uuid: %s\n" % e)
 ```
 
@@ -434,13 +434,13 @@ To retrieve a list of all billing history entries, send a GET request to `/v2/cu
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -450,12 +450,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
 
@@ -464,7 +464,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Billing History
         api_response = api_instance.list_billing_history()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->list_billing_history: %s\n" % e)
 ```
 
@@ -512,13 +512,13 @@ To retrieve a list of all invoices, send a GET request to `/v2/customers/my/invo
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import billing_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import billing_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -528,12 +528,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = billing_api.BillingApi(api_client)
 
@@ -542,7 +542,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Invoices
         api_response = api_instance.list_invoices()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BillingApi->list_invoices: %s\n" % e)
 ```
 

--- a/docs/BlockStorageActionsApi.md
+++ b/docs/BlockStorageActionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.BlockStorageActionsApi
+# digitalocean_client.BlockStorageActionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,13 +23,13 @@ To retrieve the status of a volume action, send a GET request to `/v2/volumes/$V
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -39,12 +39,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_actions_api.BlockStorageActionsApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -57,7 +57,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Volume Action
         api_response = api_instance.get_volume_action(volume_id, action_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->get_volume_action: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -66,7 +66,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Volume Action
         api_response = api_instance.get_volume_action(volume_id, action_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->get_volume_action: %s\n" % e)
 ```
 
@@ -120,13 +120,13 @@ To retrieve all actions that have been executed on a volume, send a GET request 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -136,12 +136,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_actions_api.BlockStorageActionsApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -153,7 +153,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Actions for a Volume
         api_response = api_instance.list_all_volume_actions(volume_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->list_all_volume_actions: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -162,7 +162,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Actions for a Volume
         api_response = api_instance.list_all_volume_actions(volume_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->list_all_volume_actions: %s\n" % e)
 ```
 
@@ -215,14 +215,14 @@ To initiate an action on a block storage volume by Id, send a POST request to `~
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_actions_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_actions_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -232,12 +232,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_actions_api.BlockStorageActionsApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -250,7 +250,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate A Block Storage Action By Volume Id
         api_response = api_instance.post_volume_action_by_id(volume_id, unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->post_volume_action_by_id: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -259,7 +259,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate A Block Storage Action By Volume Id
         api_response = api_instance.post_volume_action_by_id(volume_id, unknown_base_type, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->post_volume_action_by_id: %s\n" % e)
 ```
 
@@ -313,14 +313,14 @@ To initiate an action on a block storage volume by Id, send a POST request to `~
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_actions_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_actions_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -330,12 +330,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_actions_api.BlockStorageActionsApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -347,7 +347,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate A Block Storage Action By Volume Name
         api_response = api_instance.post_volume_action_by_name(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->post_volume_action_by_name: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -356,7 +356,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate A Block Storage Action By Volume Name
         api_response = api_instance.post_volume_action_by_name(unknown_base_type, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageActionsApi->post_volume_action_by_name: %s\n" % e)
 ```
 

--- a/docs/BlockStorageApi.md
+++ b/docs/BlockStorageApi.md
@@ -1,4 +1,4 @@
-# openapi_client.BlockStorageApi
+# digitalocean_client.BlockStorageApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -28,14 +28,14 @@ To create a new volume, send a POST request to `/v2/volumes`. Optionally, a `fil
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -45,12 +45,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -60,7 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Block Storage Volume
         api_response = api_instance.create_new_volume(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->create_new_volume: %s\n" % e)
 ```
 
@@ -112,14 +112,14 @@ To create a snapshot from a volume, sent a POST request to `/v2/volumes/$VOLUME_
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -129,12 +129,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -145,7 +145,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create Snapshot from a Volume
         api_response = api_instance.create_volume_snapshot(volume_id, unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->create_volume_snapshot: %s\n" % e)
 ```
 
@@ -198,13 +198,13 @@ To delete a block storage volume, destroying all data and removing it from your 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -214,12 +214,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -228,7 +228,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Block Storage Volume
         api_instance.delete_volume(volume_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->delete_volume: %s\n" % e)
 ```
 
@@ -279,14 +279,14 @@ Block storage volumes may also be deleted by name by sending a DELETE request wi
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
-from openapi_client.model.region_slug import RegionSlug
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.region_slug import RegionSlug
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -296,12 +296,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     name = "example" # str | The block storage volume's name. (optional)
@@ -312,7 +312,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Block Storage Volume by Name
         api_instance.delete_volume_by_name(name=name, region=region)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->delete_volume_by_name: %s\n" % e)
 ```
 
@@ -364,13 +364,13 @@ To delete a volume snapshot, send a DELETE request to `/v2/snapshots/$SNAPSHOT_I
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -380,12 +380,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     snapshot_id = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID of an existing snapshot. This will be an integer for a Droplet snapshot or a string for a volume snapshot.
@@ -394,7 +394,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Volume Snapshot
         api_instance.delete_volume_snapshot_by_id(snapshot_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->delete_volume_snapshot_by_id: %s\n" % e)
 ```
 
@@ -445,13 +445,13 @@ To show information about a block storage volume, send a GET request to `/v2/vol
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -461,12 +461,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -476,7 +476,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Block Storage Volume
         api_response = api_instance.get_volume(volume_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->get_volume: %s\n" % e)
 ```
 
@@ -527,13 +527,13 @@ To retrieve the details of a snapshot that has been created from a volume, send 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -543,12 +543,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     snapshot_id = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID of an existing snapshot. This will be an integer for a Droplet snapshot or a string for a volume snapshot.
@@ -558,7 +558,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retreive an Existing Volume Snapshot
         api_response = api_instance.get_volume_snapshot_by_id(snapshot_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->get_volume_snapshot_by_id: %s\n" % e)
 ```
 
@@ -609,14 +609,14 @@ To list all of the block storage volumes available on your account, send a GET r
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
-from openapi_client.model.region_slug import RegionSlug
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.region_slug import RegionSlug
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -626,12 +626,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     name = "example" # str | The block storage volume's name. (optional)
@@ -645,7 +645,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Block Storage Volumes
         api_response = api_instance.list_all_volumes(name=name, region=region, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->list_all_volumes: %s\n" % e)
 ```
 
@@ -698,13 +698,13 @@ To retrieve the snapshots that have been created from a volume, send a GET reque
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import block_storage_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import block_storage_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -714,12 +714,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = block_storage_api.BlockStorageApi(api_client)
     volume_id = "7724db7c-e098-11e5-b522-000f53304e51" # str | The ID of the block storage volume.
@@ -731,7 +731,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Snapshots for a Volume
         api_response = api_instance.list_volume_snapshots(volume_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->list_volume_snapshots: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -740,7 +740,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Snapshots for a Volume
         api_response = api_instance.list_volume_snapshots(volume_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling BlockStorageApi->list_volume_snapshots: %s\n" % e)
 ```
 

--- a/docs/CDNEndpointsApi.md
+++ b/docs/CDNEndpointsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.CDNEndpointsApi
+# digitalocean_client.CDNEndpointsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -25,14 +25,14 @@ To create a new CDN endpoint, send a POST request to `/v2/cdn/endpoints`. The or
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.error import Error
-from openapi_client.model.cdn_endpoint import CdnEndpoint
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.cdn_endpoint import CdnEndpoint
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -42,12 +42,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     cdn_endpoint = CdnEndpoint(
@@ -62,7 +62,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New CDN Endpoint
         api_response = api_instance.create_cdn_endpoint(cdn_endpoint)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->create_cdn_endpoint: %s\n" % e)
 ```
 
@@ -112,13 +112,13 @@ To delete a specific CDN endpoint, send a DELETE request to `/v2/cdn/endpoints/$
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -128,12 +128,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     cdn_id = "19f06b6a-3ace-4315-b086-499a0e521b76" # str | A unique identifier for a CDN endpoint.
@@ -142,7 +142,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a CDN Endpoint
         api_instance.delete_cdn_endpoint(cdn_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->delete_cdn_endpoint: %s\n" % e)
 ```
 
@@ -193,13 +193,13 @@ To show information about an existing CDN endpoint, send a GET request to `/v2/c
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -209,12 +209,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     cdn_id = "19f06b6a-3ace-4315-b086-499a0e521b76" # str | A unique identifier for a CDN endpoint.
@@ -224,7 +224,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing CDN Endpoint
         api_response = api_instance.get_cdn_endpoint(cdn_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->get_cdn_endpoint: %s\n" % e)
 ```
 
@@ -275,13 +275,13 @@ To list all of the CDN endpoints available on your account, send a GET request t
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -291,12 +291,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -308,7 +308,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All CDN Endpoints
         api_response = api_instance.list_cdn_endpoints(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->list_cdn_endpoints: %s\n" % e)
 ```
 
@@ -359,14 +359,14 @@ To purge cached content from a CDN endpoint, send a DELETE request to `/v2/cdn/e
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.purge_cache import PurgeCache
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.purge_cache import PurgeCache
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -376,12 +376,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     cdn_id = "19f06b6a-3ace-4315-b086-499a0e521b76" # str | A unique identifier for a CDN endpoint.
@@ -393,7 +393,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Purge the Cache for an Existing CDN Endpoint
         api_instance.purge_cdn_cache(cdn_id, purge_cache)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->purge_cdn_cache: %s\n" % e)
 ```
 
@@ -445,14 +445,14 @@ To update the TTL, certificate ID, or the FQDN of the custom subdomain for an ex
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import cdn_endpoints_api
-from openapi_client.model.update_endpoint import UpdateEndpoint
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import cdn_endpoints_api
+from digitalocean_client.model.update_endpoint import UpdateEndpoint
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -462,12 +462,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = cdn_endpoints_api.CDNEndpointsApi(api_client)
     cdn_id = "19f06b6a-3ace-4315-b086-499a0e521b76" # str | A unique identifier for a CDN endpoint.
@@ -482,7 +482,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a CDN Endpoint
         api_response = api_instance.update_cdn_endpoint(cdn_id, update_endpoint)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CDNEndpointsApi->update_cdn_endpoint: %s\n" % e)
 ```
 

--- a/docs/CertificatesApi.md
+++ b/docs/CertificatesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.CertificatesApi
+# digitalocean_client.CertificatesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,15 +23,15 @@ To upload new SSL certificate which you have previously generated, send a POST r
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import certificates_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.inline_response201 import InlineResponse201
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import certificates_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.inline_response201 import InlineResponse201
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -41,12 +41,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = certificates_api.CertificatesApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -56,7 +56,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Certificate
         api_response = api_instance.create_certificates(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CertificatesApi->create_certificates: %s\n" % e)
 ```
 
@@ -106,13 +106,13 @@ To delete a specific certificate, send a DELETE request to `/v2/certificates/$CE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import certificates_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import certificates_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -122,12 +122,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = certificates_api.CertificatesApi(api_client)
     certificate_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a certificate.
@@ -136,7 +136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Certificate
         api_instance.delete_certificate(certificate_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CertificatesApi->delete_certificate: %s\n" % e)
 ```
 
@@ -187,14 +187,14 @@ To show information about an existing certificate, send a GET request to `/v2/ce
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import certificates_api
-from openapi_client.model.inline_response201 import InlineResponse201
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import certificates_api
+from digitalocean_client.model.inline_response201 import InlineResponse201
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -204,12 +204,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = certificates_api.CertificatesApi(api_client)
     certificate_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a certificate.
@@ -219,7 +219,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Certificate
         api_response = api_instance.get_certificate(certificate_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CertificatesApi->get_certificate: %s\n" % e)
 ```
 
@@ -270,13 +270,13 @@ To list all of the certificates available on your account, send a GET request to
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import certificates_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import certificates_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -286,12 +286,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = certificates_api.CertificatesApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -303,7 +303,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Certificates
         api_response = api_instance.list_certificates(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling CertificatesApi->list_certificates: %s\n" % e)
 ```
 

--- a/docs/ContainerRegistryApi.md
+++ b/docs/ContainerRegistryApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ContainerRegistryApi
+# digitalocean_client.ContainerRegistryApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -35,14 +35,14 @@ To create your container registry, send a POST request to `/v2/registry`.  The `
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.registry_create import RegistryCreate
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.registry_create import RegistryCreate
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -52,12 +52,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_create = RegistryCreate(
@@ -70,7 +70,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create Container Registry
         api_response = api_instance.create_registry(registry_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->create_registry: %s\n" % e)
 ```
 
@@ -120,13 +120,13 @@ To delete your container registry, destroying all container image data stored in
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -136,12 +136,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
 
@@ -149,7 +149,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete Container Registry
         api_instance.delete_registry()
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->delete_registry: %s\n" % e)
 ```
 
@@ -197,13 +197,13 @@ To delete a container repository manifest by digest, send a DELETE request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -213,12 +213,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -229,7 +229,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete Container Registry Repository Manifest
         api_instance.delete_repository_manifest(registry_name, repository_name, manifest_digest)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->delete_repository_manifest: %s\n" % e)
 ```
 
@@ -282,13 +282,13 @@ To delete a container repository tag, send a DELETE request to `/v2/registry/$RE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -298,12 +298,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -314,7 +314,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete Container Registry Repository Tag
         api_instance.delete_repository_tag(registry_name, repository_name, repository_tag)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->delete_repository_tag: %s\n" % e)
 ```
 
@@ -367,14 +367,14 @@ In order to access your container registry with the Docker client or from a Kube
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.docker_credentials import DockerCredentials
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.docker_credentials import DockerCredentials
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -384,12 +384,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     expiry_seconds = 3600 # int | The duration in seconds that the returned registry credentials will be valid. If not set or 0, the credentials will not expire. (optional) if omitted the server will use the default value of 0
@@ -401,7 +401,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Docker Credentials for Container Registry
         api_response = api_instance.get_docker_credentials(expiry_seconds=expiry_seconds, read_write=read_write)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->get_docker_credentials: %s\n" % e)
 ```
 
@@ -452,14 +452,14 @@ To get information about the currently-active garbage collection for a registry,
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2007 import InlineResponse2007
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2007 import InlineResponse2007
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -469,12 +469,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -484,7 +484,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Active Garbage Collection
         api_response = api_instance.get_garbage_collection(registry_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->get_garbage_collection: %s\n" % e)
 ```
 
@@ -535,13 +535,13 @@ To get information about your container registry, send a GET request to `/v2/reg
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -551,12 +551,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
 
@@ -565,7 +565,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Container Registry Information
         api_response = api_instance.get_registry()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->get_registry: %s\n" % e)
 ```
 
@@ -612,14 +612,14 @@ There are multiple subscription tiers available for container registry. Each tie
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2009 import InlineResponse2009
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2009 import InlineResponse2009
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -629,12 +629,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
 
@@ -643,7 +643,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Available Subscription Tiers
         api_response = api_instance.get_registry_options()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->get_registry_options: %s\n" % e)
 ```
 
@@ -690,14 +690,14 @@ A subscription is automatically created when you configure your container regist
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.subscription import Subscription
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.subscription import Subscription
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -707,12 +707,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
 
@@ -721,7 +721,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Subscription Information
         api_response = api_instance.get_registry_subscription()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->get_registry_subscription: %s\n" % e)
 ```
 
@@ -768,14 +768,14 @@ To get information about past garbage collections for a registry, send a GET req
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2008 import InlineResponse2008
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2008 import InlineResponse2008
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -785,12 +785,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -802,7 +802,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Garbage Collections
         api_response = api_instance.list_garbage_collections(registry_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_garbage_collections: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -811,7 +811,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Garbage Collections
         api_response = api_instance.list_garbage_collections(registry_name, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_garbage_collections: %s\n" % e)
 ```
 
@@ -864,13 +864,13 @@ To list all repositories in your container registry, send a GET request to `/v2/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -880,12 +880,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -897,7 +897,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Container Registry Repositories
         api_response = api_instance.list_registry_repositories(registry_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_registry_repositories: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -906,7 +906,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Container Registry Repositories
         api_response = api_instance.list_registry_repositories(registry_name, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_registry_repositories: %s\n" % e)
 ```
 
@@ -959,13 +959,13 @@ To list all tags in your container registry repository, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -975,12 +975,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -993,7 +993,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Container Registry Repository Tags
         api_response = api_instance.list_repository_tags(registry_name, repository_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_repository_tags: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1002,7 +1002,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Container Registry Repository Tags
         api_response = api_instance.list_repository_tags(registry_name, repository_name, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->list_repository_tags: %s\n" % e)
 ```
 
@@ -1056,15 +1056,15 @@ After creating your registry, you can switch to a different subscription tier to
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.subscription import Subscription
-from openapi_client.model.error import Error
-from openapi_client.model.inline_object4 import InlineObject4
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.subscription import Subscription
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_object4 import InlineObject4
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1074,12 +1074,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     inline_object4 = InlineObject4(
@@ -1092,7 +1092,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update Subscription Tier
         api_response = api_instance.post_registry_subscription(inline_object4=inline_object4)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->post_registry_subscription: %s\n" % e)
 ```
 
@@ -1142,14 +1142,14 @@ Garbage collection enables users to clear out unreferenced blobs (layer & manife
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2007 import InlineResponse2007
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2007 import InlineResponse2007
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1159,12 +1159,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -1174,7 +1174,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Start Garbage Collection
         api_response = api_instance.run_garbage_collection(registry_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->run_garbage_collection: %s\n" % e)
 ```
 
@@ -1225,15 +1225,15 @@ To cancel the currently-active garbage collection for a registry, send a PUT req
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.update_registry import UpdateRegistry
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2007 import InlineResponse2007
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.update_registry import UpdateRegistry
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2007 import InlineResponse2007
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1243,12 +1243,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     registry_name = "example" # str | The name of a container registry.
@@ -1262,7 +1262,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update Garbage Collection
         api_response = api_instance.update_garbage_collection(registry_name, garbage_collection_uuid, update_registry)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->update_garbage_collection: %s\n" % e)
 ```
 
@@ -1315,14 +1315,14 @@ To validate that a container registry name is available for use, send a POST req
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import container_registry_api
-from openapi_client.model.error import Error
-from openapi_client.model.validate_registry import ValidateRegistry
+import digitalocean_client
+from digitalocean_client.api import container_registry_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.validate_registry import ValidateRegistry
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1332,12 +1332,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = container_registry_api.ContainerRegistryApi(api_client)
     validate_registry = ValidateRegistry(
@@ -1348,7 +1348,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Validate a Container Registry Name
         api_instance.validate_registry_name(validate_registry)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ContainerRegistryApi->validate_registry_name: %s\n" % e)
 ```
 

--- a/docs/DatabasesApi.md
+++ b/docs/DatabasesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.DatabasesApi
+# digitalocean_client.DatabasesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -54,15 +54,15 @@ For PostgreSQL database clusters, connection pools can be used to allow a databa
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.connection_pool import ConnectionPool
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2015 import InlineResponse2015
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.connection_pool import ConnectionPool
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2015 import InlineResponse2015
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -72,12 +72,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -96,7 +96,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Add a New Connection Pool (PostgreSQL)
         api_response = api_instance.add_connection_pool(database_cluster_uuid, connection_pool)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->add_connection_pool: %s\n" % e)
 ```
 
@@ -148,15 +148,15 @@ To add a new database to an existing cluster, send a POST request to `/v2/databa
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2014 import InlineResponse2014
-from openapi_client.model.error import Error
-from openapi_client.model.database import Database
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2014 import InlineResponse2014
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.database import Database
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -166,12 +166,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -184,7 +184,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Add a New Database
         api_response = api_instance.add_database(database_cluster_uuid, database)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->add_database: %s\n" % e)
 ```
 
@@ -236,15 +236,15 @@ To add a new database user, send a POST request to `/v2/databases/$DATABASE_ID/u
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2013 import InlineResponse2013
-from openapi_client.model.database_user import DatabaseUser
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2013 import InlineResponse2013
+from digitalocean_client.model.database_user import DatabaseUser
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -254,12 +254,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -275,7 +275,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Add a Database User
         api_response = api_instance.add_user(database_cluster_uuid, database_user)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->add_user: %s\n" % e)
 ```
 
@@ -327,15 +327,15 @@ To create a database cluster, send a POST request to `/v2/databases`. The respon
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2011 import InlineResponse2011
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2011 import InlineResponse2011
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -345,12 +345,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -360,7 +360,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Database Cluster
         api_response = api_instance.create_database_cluster(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->create_database_cluster: %s\n" % e)
 ```
 
@@ -411,15 +411,15 @@ To create a read-only replica for a PostgreSQL or MySQL database cluster, send a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2012 import InlineResponse2012
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2012 import InlineResponse2012
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -429,12 +429,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -445,7 +445,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a Read-only Replica
         api_response = api_instance.create_replica(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->create_replica: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -454,7 +454,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a Read-only Replica
         api_response = api_instance.create_replica(database_cluster_uuid, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->create_replica: %s\n" % e)
 ```
 
@@ -506,13 +506,13 @@ To delete a specific connection pool for a PostgreSQL database cluster, send a D
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -522,12 +522,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -537,7 +537,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Connection Pool (PostgreSQL)
         api_instance.delete_connection_pool(database_cluster_uuid, pool_name)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->delete_connection_pool: %s\n" % e)
 ```
 
@@ -589,13 +589,13 @@ To delete a specific database, send a DELETE request to `/v2/databases/$DATABASE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -605,12 +605,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -620,7 +620,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Database
         api_instance.delete_database(database_cluster_uuid, database_name)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->delete_database: %s\n" % e)
 ```
 
@@ -672,13 +672,13 @@ To stop an online migration, send a DELETE request to `/v2/databases/$DATABASE_I
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -688,12 +688,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -703,7 +703,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Stop an Online Migration
         api_instance.delete_online_migration(database_cluster_uuid, migration_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->delete_online_migration: %s\n" % e)
 ```
 
@@ -755,13 +755,13 @@ To remove a specific database user, send a DELETE request to `/v2/databases/$DAT
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -771,12 +771,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -786,7 +786,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove a Database User
         api_instance.delete_user(database_cluster_uuid, username)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->delete_user: %s\n" % e)
 ```
 
@@ -838,13 +838,13 @@ To destroy a specific database, send a DELETE request to `/v2/databases/$DATABAS
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -854,12 +854,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -868,7 +868,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Destroy a Database Cluster
         api_instance.destroy_cluster(database_cluster_uuid)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->destroy_cluster: %s\n" % e)
 ```
 
@@ -919,13 +919,13 @@ To destroy a specific read-only replica, send a DELETE request to `/v2/databases
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -935,12 +935,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -950,7 +950,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Destroy a Read-only Replica
         api_instance.destroy_replica(database_cluster_uuid, replica_name)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->destroy_replica: %s\n" % e)
 ```
 
@@ -1002,14 +1002,14 @@ To retrieve the public certificate used to secure the connection to the database
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2001 import InlineResponse2001
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2001 import InlineResponse2001
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1019,12 +1019,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1034,7 +1034,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the Public Certificate
         api_response = api_instance.get_ca(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_ca: %s\n" % e)
 ```
 
@@ -1085,14 +1085,14 @@ To show information about an existing connection pool for a PostgreSQL database 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2015 import InlineResponse2015
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2015 import InlineResponse2015
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1102,12 +1102,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1118,7 +1118,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Existing Connection Pool (PostgreSQL)
         api_response = api_instance.get_connection_pool(database_cluster_uuid, pool_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_connection_pool: %s\n" % e)
 ```
 
@@ -1170,14 +1170,14 @@ To show information about an existing database cluster, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2014 import InlineResponse2014
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2014 import InlineResponse2014
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1187,12 +1187,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1203,7 +1203,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Database
         api_response = api_instance.get_database(database_cluster_uuid, database_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_database: %s\n" % e)
 ```
 
@@ -1255,14 +1255,14 @@ To show information about an existing database cluster, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2011 import InlineResponse2011
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2011 import InlineResponse2011
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1272,12 +1272,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1287,7 +1287,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Database Cluster
         api_response = api_instance.get_database_cluster(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_database_cluster: %s\n" % e)
 ```
 
@@ -1338,14 +1338,14 @@ To retrieve the configured eviction policy for an existing Redis cluster, send a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.eviction_policy import EvictionPolicy
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.eviction_policy import EvictionPolicy
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1355,12 +1355,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1370,7 +1370,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the Eviction Policy for a Redis Cluster
         api_response = api_instance.get_eviction_policy(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_eviction_policy: %s\n" % e)
 ```
 
@@ -1421,14 +1421,14 @@ To retrieve the status of an online migration, send a GET request to `/v2/databa
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.online_migration import OnlineMigration
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.online_migration import OnlineMigration
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1438,12 +1438,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1453,7 +1453,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the Status of an Online Migration
         api_response = api_instance.get_migration_status(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_migration_status: %s\n" % e)
 ```
 
@@ -1504,14 +1504,14 @@ To show information about an existing database replica, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2012 import InlineResponse2012
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2012 import InlineResponse2012
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1521,12 +1521,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1537,7 +1537,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Read-only Replica
         api_response = api_instance.get_replica(database_cluster_uuid, replica_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_replica: %s\n" % e)
 ```
 
@@ -1589,14 +1589,14 @@ To retrieve the configured SQL modes for an existing MySQL cluster, send a GET r
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.sql_mode import SqlMode
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.sql_mode import SqlMode
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1606,12 +1606,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1621,7 +1621,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the SQL Modes for a MySQL Cluster
         api_response = api_instance.get_sql_mode(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_sql_mode: %s\n" % e)
 ```
 
@@ -1672,14 +1672,14 @@ To show information about an existing database user, send a GET request to `/v2/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2013 import InlineResponse2013
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2013 import InlineResponse2013
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1689,12 +1689,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1705,7 +1705,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Database User
         api_response = api_instance.get_user(database_cluster_uuid, username)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->get_user: %s\n" % e)
 ```
 
@@ -1757,14 +1757,14 @@ To list all of the connection pools available to a PostgreSQL database cluster, 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.connection_pools import ConnectionPools
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.connection_pools import ConnectionPools
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1774,12 +1774,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1789,7 +1789,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Connection Pools (PostgreSQL)
         api_response = api_instance.list_connection_pools(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_connection_pools: %s\n" % e)
 ```
 
@@ -1840,14 +1840,14 @@ To list all of the available backups of a PostgreSQL or MySQL database cluster, 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response2002 import InlineResponse2002
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response2002 import InlineResponse2002
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1857,12 +1857,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -1872,7 +1872,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Backups for a Database Cluster
         api_response = api_instance.list_database_backups(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_database_backups: %s\n" % e)
 ```
 
@@ -1923,13 +1923,13 @@ To list all of the database clusters available on your account, send a GET reque
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1939,12 +1939,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     tag_name = "production" # str | Limits the results to database clusters with a specific tag. (optional)
@@ -1955,7 +1955,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Database Clusters
         api_response = api_instance.list_database_clusters(tag_name=tag_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_database_clusters: %s\n" % e)
 ```
 
@@ -2006,13 +2006,13 @@ To list all of a database cluster's firewall rules (known as \"trusted sources\"
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2022,12 +2022,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2037,7 +2037,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Firewall Rules (Trusted Sources) for a Database Cluster
         api_response = api_instance.list_database_firewalls(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_database_firewalls: %s\n" % e)
 ```
 
@@ -2088,13 +2088,13 @@ To list all of the databases in a clusters, send a GET request to `/v2/databases
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2104,12 +2104,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2119,7 +2119,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Databases
         api_response = api_instance.list_databases(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_databases: %s\n" % e)
 ```
 
@@ -2170,13 +2170,13 @@ To list all of the read-only replicas associated with a database cluster, send a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2186,12 +2186,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2201,7 +2201,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Read-only Replicas
         api_response = api_instance.list_replicas(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_replicas: %s\n" % e)
 ```
 
@@ -2252,13 +2252,13 @@ To list all of the users for your database cluster, send a GET request to `/v2/d
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2268,12 +2268,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2283,7 +2283,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List all Database Users
         api_response = api_instance.list_users(database_cluster_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->list_users: %s\n" % e)
 ```
 
@@ -2334,15 +2334,15 @@ To reset the password for a database user, send a POST request to `/v2/databases
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.inline_response2013 import InlineResponse2013
-from openapi_client.model.inline_object3 import InlineObject3
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.inline_response2013 import InlineResponse2013
+from digitalocean_client.model.inline_object3 import InlineObject3
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2352,12 +2352,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2373,7 +2373,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Reset a Database User's Password or Authentication Method
         api_response = api_instance.reset_auth(database_cluster_uuid, username, inline_object3)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->reset_auth: %s\n" % e)
 ```
 
@@ -2426,14 +2426,14 @@ To migrate a database cluster to a new region, send a `PUT` request to `/v2/data
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_object1 import InlineObject1
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_object1 import InlineObject1
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2443,12 +2443,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2460,7 +2460,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Migrate a Database Cluster to a New Region
         api_instance.update_database_cluster(database_cluster_uuid, inline_object1)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_database_cluster: %s\n" % e)
 ```
 
@@ -2512,14 +2512,14 @@ To resize a database cluster, send a PUT request to `/v2/databases/$DATABASE_ID/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.database_cluster_resize import DatabaseClusterResize
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.database_cluster_resize import DatabaseClusterResize
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2529,12 +2529,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2547,7 +2547,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Resize a Database Cluster
         api_instance.update_database_cluster_size(database_cluster_uuid, database_cluster_resize)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_database_cluster_size: %s\n" % e)
 ```
 
@@ -2599,14 +2599,14 @@ To update a database cluster's firewall rules (known as \"trusted sources\" in t
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_object2 import InlineObject2
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_object2 import InlineObject2
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2616,12 +2616,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2640,7 +2640,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Update Firewall Rules (Trusted Sources) for a Database
         api_instance.update_database_firewall(database_cluster_uuid, inline_object2)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_database_firewall: %s\n" % e)
 ```
 
@@ -2692,14 +2692,14 @@ To configure an eviction policy for an existing Redis cluster, send a PUT reques
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.eviction_policy import EvictionPolicy
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.eviction_policy import EvictionPolicy
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2709,12 +2709,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2726,7 +2726,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Configure the Eviction Policy for a Redis Cluster
         api_instance.update_eviction_policy(database_cluster_uuid, eviction_policy)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_eviction_policy: %s\n" % e)
 ```
 
@@ -2778,14 +2778,14 @@ To configure the window when automatic maintenance should be performed for a dat
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.database_maintenance_window import DatabaseMaintenanceWindow
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.database_maintenance_window import DatabaseMaintenanceWindow
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2795,12 +2795,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2813,7 +2813,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Configure a Database Cluster's Maintenance Window
         api_instance.update_maintenance_window(database_cluster_uuid, database_maintenance_window)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_maintenance_window: %s\n" % e)
 ```
 
@@ -2865,15 +2865,15 @@ To start an online migration, send a PUT request to `/v2/databases/$DATABASE_ID/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.source_database import SourceDatabase
-from openapi_client.model.online_migration import OnlineMigration
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.source_database import SourceDatabase
+from digitalocean_client.model.online_migration import OnlineMigration
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2883,12 +2883,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2902,7 +2902,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Start an Online Migration
         api_response = api_instance.update_online_migration(database_cluster_uuid, source_database)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_online_migration: %s\n" % e)
 ```
 
@@ -2954,14 +2954,14 @@ To configure the SQL modes for an existing MySQL cluster, send a PUT request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import databases_api
-from openapi_client.model.error import Error
-from openapi_client.model.sql_mode import SqlMode
+import digitalocean_client
+from digitalocean_client.api import databases_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.sql_mode import SqlMode
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2971,12 +2971,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = databases_api.DatabasesApi(api_client)
     database_cluster_uuid = "9cc10173-e9ea-4176-9dbc-a4cee4c4ff30" # str | A unique identifier for a database cluster.
@@ -2988,7 +2988,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Update SQL Mode for a Cluster
         api_instance.update_sql_mode(database_cluster_uuid, sql_mode)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DatabasesApi->update_sql_mode: %s\n" % e)
 ```
 

--- a/docs/DomainRecordsApi.md
+++ b/docs/DomainRecordsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.DomainRecordsApi
+# digitalocean_client.DomainRecordsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -25,14 +25,14 @@ To create a new record to a domain, send a POST request to `/v2/domains/$DOMAIN_
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -42,12 +42,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -58,7 +58,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Domain Record
         api_response = api_instance.create_domain_record(domain_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->create_domain_record: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -67,7 +67,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Domain Record
         api_response = api_instance.create_domain_record(domain_name, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->create_domain_record: %s\n" % e)
 ```
 
@@ -119,13 +119,13 @@ To delete a record for a domain, send a DELETE request to `/v2/domains/$DOMAIN_N
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -135,12 +135,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -150,7 +150,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Domain Record
         api_instance.delete_domain_record(domain_name, domain_record_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->delete_domain_record: %s\n" % e)
 ```
 
@@ -202,13 +202,13 @@ To retrieve a specific domain record, send a GET request to `/v2/domains/$DOMAIN
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -218,12 +218,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -234,7 +234,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Domain Record
         api_response = api_instance.get_domain_record(domain_name, domain_record_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->get_domain_record: %s\n" % e)
 ```
 
@@ -286,13 +286,13 @@ To get a listing of all records configured for a domain, send a GET request to `
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -302,12 +302,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -319,7 +319,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Domain Records
         api_response = api_instance.list_all_domain_records(domain_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->list_all_domain_records: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -328,7 +328,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Domain Records
         api_response = api_instance.list_all_domain_records(domain_name, name=name, type=type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->list_all_domain_records: %s\n" % e)
 ```
 
@@ -381,14 +381,14 @@ To update an existing record, send a PATCH request to `/v2/domains/$DOMAIN_NAME/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.error import Error
-from openapi_client.model.domain_record import DomainRecord
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.domain_record import DomainRecord
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -398,12 +398,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -425,7 +425,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Domain Record
         api_response = api_instance.patch_update_domain_record(domain_name, domain_record_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->patch_update_domain_record: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -434,7 +434,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Domain Record
         api_response = api_instance.patch_update_domain_record(domain_name, domain_record_id, domain_record=domain_record)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->patch_update_domain_record: %s\n" % e)
 ```
 
@@ -487,14 +487,14 @@ To update an existing record, send a PUT request to `/v2/domains/$DOMAIN_NAME/re
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domain_records_api
-from openapi_client.model.error import Error
-from openapi_client.model.domain_record import DomainRecord
+import digitalocean_client
+from digitalocean_client.api import domain_records_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.domain_record import DomainRecord
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -504,12 +504,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domain_records_api.DomainRecordsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -531,7 +531,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Domain Record
         api_response = api_instance.update_domain_record(domain_name, domain_record_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->update_domain_record: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -540,7 +540,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Domain Record
         api_response = api_instance.update_domain_record(domain_name, domain_record_id, domain_record=domain_record)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainRecordsApi->update_domain_record: %s\n" % e)
 ```
 

--- a/docs/DomainsApi.md
+++ b/docs/DomainsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.DomainsApi
+# digitalocean_client.DomainsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,14 +23,14 @@ To create a new domain, send a POST request to `/v2/domains`. Set the \"name\" a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domains_api
-from openapi_client.model.error import Error
-from openapi_client.model.domain import Domain
+import digitalocean_client
+from digitalocean_client.api import domains_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.domain import Domain
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -40,12 +40,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domains_api.DomainsApi(api_client)
     domain = Domain(
@@ -59,7 +59,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Domain
         api_response = api_instance.create_domain(domain=domain)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainsApi->create_domain: %s\n" % e)
 ```
 
@@ -109,13 +109,13 @@ To delete a domain, send a DELETE request to `/v2/domains/$DOMAIN_NAME`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domains_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domains_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -125,12 +125,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domains_api.DomainsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -139,7 +139,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Domain
         api_instance.delete_domain(domain_name)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainsApi->delete_domain: %s\n" % e)
 ```
 
@@ -190,13 +190,13 @@ To get details about a specific domain, send a GET request to `/v2/domains/$DOMA
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domains_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domains_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -206,12 +206,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domains_api.DomainsApi(api_client)
     domain_name = "example.com" # str | The name of the domain itself.
@@ -221,7 +221,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Domain
         api_response = api_instance.get_domain(domain_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainsApi->get_domain: %s\n" % e)
 ```
 
@@ -272,13 +272,13 @@ To retrieve a list of all of the domains in your account, send a GET request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import domains_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import domains_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -288,12 +288,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = domains_api.DomainsApi(api_client)
 
@@ -302,7 +302,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Domains
         api_response = api_instance.list_all_domains()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DomainsApi->list_all_domains: %s\n" % e)
 ```
 

--- a/docs/DropletActionsApi.md
+++ b/docs/DropletActionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.DropletActionsApi
+# digitalocean_client.DropletActionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,13 +23,13 @@ To retrieve a Droplet action, send a GET request to `/v2/droplets/$DROPLET_ID/ac
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplet_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplet_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -39,12 +39,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplet_actions_api.DropletActionsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -55,7 +55,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve a Droplet Action
         api_response = api_instance.get_droplet_action(droplet_id, action_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->get_droplet_action: %s\n" % e)
 ```
 
@@ -107,13 +107,13 @@ To retrieve a list of all actions that have been executed for a Droplet, send a 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplet_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplet_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -123,12 +123,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplet_actions_api.DropletActionsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -140,7 +140,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Actions for a Droplet
         api_response = api_instance.list_droplet_actions(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->list_droplet_actions: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -149,7 +149,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Actions for a Droplet
         api_response = api_instance.list_droplet_actions(droplet_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->list_droplet_actions: %s\n" % e)
 ```
 
@@ -202,14 +202,14 @@ To initiate an action on a Droplet send a POST request to `/v2/droplets/$DROPLET
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplet_actions_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplet_actions_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -219,12 +219,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplet_actions_api.DropletActionsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -235,7 +235,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate a Droplet Action
         api_response = api_instance.post_droplet_action(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->post_droplet_action: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -244,7 +244,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate a Droplet Action
         api_response = api_instance.post_droplet_action(droplet_id, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->post_droplet_action: %s\n" % e)
 ```
 
@@ -296,14 +296,14 @@ Some actions can be performed in bulk on tagged Droplets. The actions can be ini
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplet_actions_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplet_actions_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -313,12 +313,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplet_actions_api.DropletActionsApi(api_client)
     tag_name = "env:prod" # str | Used to filter Droplets by a specific tag. (optional)
@@ -330,7 +330,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Acting on Tagged Droplets
         api_response = api_instance.post_droplet_action_by_tag(tag_name=tag_name, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletActionsApi->post_droplet_action_by_tag: %s\n" % e)
 ```
 

--- a/docs/DropletsApi.md
+++ b/docs/DropletsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.DropletsApi
+# digitalocean_client.DropletsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -35,14 +35,14 @@ To create a new Droplet, send a POST request to `/v2/droplets` setting the requi
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -52,12 +52,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE |  (optional)
@@ -68,7 +68,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Droplet
         api_response = api_instance.create_droplet(unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->create_droplet: %s\n" % e)
 ```
 
@@ -118,13 +118,13 @@ To delete a Droplet, send a DELETE request to `/v2/droplets/$DROPLET_ID`.  A suc
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -134,12 +134,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -148,7 +148,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete an Existing Droplet
         api_instance.destroy_droplet(droplet_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->destroy_droplet: %s\n" % e)
 ```
 
@@ -199,13 +199,13 @@ To delete **all** Droplets assigned to a specific tag, include the `tag_name` qu
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -215,12 +215,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     tag_name = "env:test" # str | Specifies Droplets to be deleted by tag.
@@ -229,7 +229,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Deleting Droplets by Tag
         api_instance.destroy_droplets_by_tag(tag_name)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->destroy_droplets_by_tag: %s\n" % e)
 ```
 
@@ -280,13 +280,13 @@ To destroy a Droplet along with all of its associated resources, send a DELETE r
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -296,12 +296,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -311,7 +311,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Destroy a Droplet and All of its Associated Resources (Dangerous)
         api_instance.destroy_with_associated_resources_dangerous(droplet_id, x_dangerous)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->destroy_with_associated_resources_dangerous: %s\n" % e)
 ```
 
@@ -363,13 +363,13 @@ To destroy a Droplet along with a sub-set of its associated resources, send a DE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -379,12 +379,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -393,7 +393,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Selectively Destroy a Droplet and its Associated Resources
         api_instance.destroy_with_associated_resources_selective(droplet_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->destroy_with_associated_resources_selective: %s\n" % e)
 ```
 
@@ -444,14 +444,14 @@ To check on the status of a request to destroy a Droplet with its associated res
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.associated_resource_status import AssociatedResourceStatus
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.associated_resource_status import AssociatedResourceStatus
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -461,12 +461,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -476,7 +476,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Check Status of a Droplet Destroy with Associated Resources Request
         api_response = api_instance.get_destroy_with_associated_resources_status(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->get_destroy_with_associated_resources_status: %s\n" % e)
 ```
 
@@ -527,13 +527,13 @@ To show information about an individual Droplet, send a GET request to `/v2/drop
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -543,12 +543,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -558,7 +558,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Droplet
         api_response = api_instance.get_droplet(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->get_droplet: %s\n" % e)
 ```
 
@@ -609,14 +609,14 @@ To retrieve a list of all Droplets that are co-located on the same physical hard
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.neighbor_ids import NeighborIds
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.neighbor_ids import NeighborIds
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -626,12 +626,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
 
@@ -640,7 +640,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Droplet Neighbors
         api_response = api_instance.list_all_droplet_neighbors_ids()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_all_droplet_neighbors_ids: %s\n" % e)
 ```
 
@@ -688,13 +688,13 @@ To list all Droplets in your account, send a GET request to `/v2/droplets`.  The
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -704,12 +704,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -722,7 +722,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Droplets
         api_response = api_instance.list_all_droplets(per_page=per_page, page=page, tag_name=tag_name)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_all_droplets: %s\n" % e)
 ```
 
@@ -774,13 +774,13 @@ To list the associated billable resources that can be destroyed along with a Dro
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -790,12 +790,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -805,7 +805,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Associated Resources for a Droplet
         api_response = api_instance.list_droplet_associated_resources(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_associated_resources: %s\n" % e)
 ```
 
@@ -856,13 +856,13 @@ To retrieve any backups associated with a Droplet, send a GET request to `/v2/dr
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -872,12 +872,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -889,7 +889,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Backups for a Droplet
         api_response = api_instance.list_droplet_backups(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_backups: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -898,7 +898,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Backups for a Droplet
         api_response = api_instance.list_droplet_backups(droplet_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_backups: %s\n" % e)
 ```
 
@@ -951,13 +951,13 @@ To retrieve a list of all firewalls available to a Droplet, send a GET request t
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -967,12 +967,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -984,7 +984,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List all Firewalls Applied to a Droplet
         api_response = api_instance.list_droplet_firewalls(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_firewalls: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -993,7 +993,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List all Firewalls Applied to a Droplet
         api_response = api_instance.list_droplet_firewalls(droplet_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_firewalls: %s\n" % e)
 ```
 
@@ -1046,13 +1046,13 @@ To retrieve a list of all kernels available to a Droplet, send a GET request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1062,12 +1062,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -1079,7 +1079,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Available Kernels for a Droplet
         api_response = api_instance.list_droplet_kernels(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_kernels: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1088,7 +1088,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Available Kernels for a Droplet
         api_response = api_instance.list_droplet_kernels(droplet_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_kernels: %s\n" % e)
 ```
 
@@ -1141,13 +1141,13 @@ To retrieve a list of any \"neighbors\" (i.e. Droplets that are co-located on th
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1157,12 +1157,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -1172,7 +1172,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Neighbors for a Droplet
         api_response = api_instance.list_droplet_neighbors(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_neighbors: %s\n" % e)
 ```
 
@@ -1223,13 +1223,13 @@ To retrieve the snapshots that have been created from a Droplet, send a GET requ
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1239,12 +1239,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -1256,7 +1256,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Snapshots for a Droplet
         api_response = api_instance.list_droplet_snapshots(droplet_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_snapshots: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1265,7 +1265,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Snapshots for a Droplet
         api_response = api_instance.list_droplet_snapshots(droplet_id, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->list_droplet_snapshots: %s\n" % e)
 ```
 
@@ -1318,13 +1318,13 @@ If the status of a request to destroy a Droplet with its associated resources re
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import droplets_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import droplets_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1334,12 +1334,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = droplets_api.DropletsApi(api_client)
     droplet_id = 3164444 # int | A unique identifier for a Droplet instance.
@@ -1348,7 +1348,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Retry a Droplet Destroy with Associated Resources Request
         api_instance.retry_destroy_with_associated_resource(droplet_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling DropletsApi->retry_destroy_with_associated_resource: %s\n" % e)
 ```
 

--- a/docs/FirewallsApi.md
+++ b/docs/FirewallsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.FirewallsApi
+# digitalocean_client.FirewallsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -30,14 +30,14 @@ To assign a Droplet to a firewall, send a POST request to `/v2/firewalls/$FIREWA
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -47,12 +47,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -62,7 +62,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Droplets to a Firewall
         api_instance.add_firewall_droplets(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_droplets: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -70,7 +70,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Droplets to a Firewall
         api_instance.add_firewall_droplets(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_droplets: %s\n" % e)
 ```
 
@@ -123,14 +123,14 @@ To add additional access rules to a firewall, send a POST request to `/v2/firewa
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -140,12 +140,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -155,7 +155,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Rules to a Firewall
         api_instance.add_firewall_rules(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_rules: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -163,7 +163,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Rules to a Firewall
         api_instance.add_firewall_rules(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_rules: %s\n" % e)
 ```
 
@@ -216,14 +216,14 @@ To assign a tag representing a group of Droplets to a firewall, send a POST requ
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -233,12 +233,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -248,7 +248,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Tags to a Firewall
         api_instance.add_firewall_tags(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_tags: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -256,7 +256,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Tags to a Firewall
         api_instance.add_firewall_tags(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->add_firewall_tags: %s\n" % e)
 ```
 
@@ -309,14 +309,14 @@ To create a new firewall, send a POST request to `/v2/firewalls`. The request mu
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -326,12 +326,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE |  (optional)
@@ -342,7 +342,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Firewall
         api_response = api_instance.create_firewall(unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->create_firewall: %s\n" % e)
 ```
 
@@ -393,13 +393,13 @@ To delete a firewall send a DELETE request to `/v2/firewalls/$FIREWALL_ID`.  No 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -409,12 +409,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -423,7 +423,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Firewall
         api_instance.delete_firewall(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall: %s\n" % e)
 ```
 
@@ -474,14 +474,14 @@ To remove a Droplet from a firewall, send a DELETE request to `/v2/firewalls/$FI
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -491,12 +491,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -506,7 +506,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Droplets from a Firewall
         api_instance.delete_firewall_droplets(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_droplets: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -514,7 +514,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Droplets from a Firewall
         api_instance.delete_firewall_droplets(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_droplets: %s\n" % e)
 ```
 
@@ -567,14 +567,14 @@ To remove access rules from a firewall, send a DELETE request to `/v2/firewalls/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -584,12 +584,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -599,7 +599,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Rules from a Firewall
         api_instance.delete_firewall_rules(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_rules: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -607,7 +607,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Rules from a Firewall
         api_instance.delete_firewall_rules(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_rules: %s\n" % e)
 ```
 
@@ -660,14 +660,14 @@ To remove a tag representing a group of Droplets from a firewall, send a DELETE 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -677,12 +677,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -692,7 +692,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Tags from a Firewall
         api_instance.delete_firewall_tags(firewall_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_tags: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -700,7 +700,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Tags from a Firewall
         api_instance.delete_firewall_tags(firewall_id, unknown_base_type=unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->delete_firewall_tags: %s\n" % e)
 ```
 
@@ -753,13 +753,13 @@ To show information about an existing firewall, send a GET request to `/v2/firew
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -769,12 +769,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -784,7 +784,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Firewall
         api_response = api_instance.get_firewall(firewall_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->get_firewall: %s\n" % e)
 ```
 
@@ -835,13 +835,13 @@ To list all of the firewalls available on your account, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -851,12 +851,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -868,7 +868,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Firewalls
         api_response = api_instance.list_firewalls(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->list_firewalls: %s\n" % e)
 ```
 
@@ -919,14 +919,14 @@ To update the configuration of an existing firewall, send a PUT request to `/v2/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import firewalls_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import firewalls_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -936,12 +936,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = firewalls_api.FirewallsApi(api_client)
     firewall_id = "bb4b2611-3d72-467b-8602-280330ecd65c" # str | A unique ID that can be used to identify and reference a firewall.
@@ -952,7 +952,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Firewall
         api_response = api_instance.update_firewall(firewall_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->update_firewall: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -961,7 +961,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Firewall
         api_response = api_instance.update_firewall(firewall_id, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FirewallsApi->update_firewall: %s\n" % e)
 ```
 

--- a/docs/FloatingIPActionsApi.md
+++ b/docs/FloatingIPActionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.FloatingIPActionsApi
+# digitalocean_client.FloatingIPActionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -22,13 +22,13 @@ To retrieve the status of a floating IP action, send a GET request to `/v2/float
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ip_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ip_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -38,12 +38,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ip_actions_api.FloatingIPActionsApi(api_client)
     floating_ip = "45.55.96.47" # str | A floating IP address.
@@ -54,7 +54,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Floating IP Action
         api_response = api_instance.get_floating_ip_action(floating_ip, action_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPActionsApi->get_floating_ip_action: %s\n" % e)
 ```
 
@@ -106,13 +106,13 @@ To retrieve all actions that have been executed on a floating IP, send a GET req
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ip_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ip_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -122,12 +122,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ip_actions_api.FloatingIPActionsApi(api_client)
     floating_ip = "45.55.96.47" # str | A floating IP address.
@@ -137,7 +137,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Actions for a Floating IP
         api_response = api_instance.list_floating_ip_actions(floating_ip)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPActionsApi->list_floating_ip_actions: %s\n" % e)
 ```
 
@@ -188,14 +188,14 @@ To initiate an action on a floating IP send a POST request to `/v2/floating_ips/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ip_actions_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ip_actions_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -205,12 +205,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ip_actions_api.FloatingIPActionsApi(api_client)
     floating_ip = "45.55.96.47" # str | A floating IP address.
@@ -221,7 +221,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate a Floating IP Action
         api_response = api_instance.post_floating_ip_action(floating_ip)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPActionsApi->post_floating_ip_action: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -230,7 +230,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate a Floating IP Action
         api_response = api_instance.post_floating_ip_action(floating_ip, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPActionsApi->post_floating_ip_action: %s\n" % e)
 ```
 

--- a/docs/FloatingIPsApi.md
+++ b/docs/FloatingIPsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.FloatingIPsApi
+# digitalocean_client.FloatingIPsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,15 +23,15 @@ On creation, a floating IP must be either assigned to a Droplet or reserved to a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ips_api
-from openapi_client.model.error import Error
-from openapi_client.model.floating_ip_create import FloatingIpCreate
-from openapi_client.model.inline_response202 import InlineResponse202
+import digitalocean_client
+from digitalocean_client.api import floating_ips_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.floating_ip_create import FloatingIpCreate
+from digitalocean_client.model.inline_response202 import InlineResponse202
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -41,12 +41,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ips_api.FloatingIPsApi(api_client)
     floating_ip_create = FloatingIpCreate(None) # FloatingIpCreate | 
@@ -56,7 +56,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Floating IP
         api_response = api_instance.create_floating_ip(floating_ip_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPsApi->create_floating_ip: %s\n" % e)
 ```
 
@@ -106,13 +106,13 @@ To delete a floating IP and remove it from your account, send a DELETE request t
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ips_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ips_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -122,12 +122,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ips_api.FloatingIPsApi(api_client)
     floating_ip = "45.55.96.47" # str | A floating IP address.
@@ -136,7 +136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Floating IPs
         api_instance.delete_floating_ip(floating_ip)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPsApi->delete_floating_ip: %s\n" % e)
 ```
 
@@ -187,14 +187,14 @@ To show information about a floating IP, send a GET request to `/v2/floating_ips
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ips_api
-from openapi_client.model.inline_response2003 import InlineResponse2003
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ips_api
+from digitalocean_client.model.inline_response2003 import InlineResponse2003
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -204,12 +204,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ips_api.FloatingIPsApi(api_client)
     floating_ip = "45.55.96.47" # str | A floating IP address.
@@ -219,7 +219,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Floating IP
         api_response = api_instance.get_floating_ip(floating_ip)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPsApi->get_floating_ip: %s\n" % e)
 ```
 
@@ -270,13 +270,13 @@ To list all of the floating IPs available on your account, send a GET request to
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import floating_ips_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import floating_ips_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -286,12 +286,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = floating_ips_api.FloatingIPsApi(api_client)
 
@@ -300,7 +300,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Floating IPs
         api_response = api_instance.list_floating_ips()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling FloatingIPsApi->list_floating_ips: %s\n" % e)
 ```
 

--- a/docs/ImageActionsApi.md
+++ b/docs/ImageActionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ImageActionsApi
+# digitalocean_client.ImageActionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -22,14 +22,14 @@ To retrieve the status of an image action, send a GET request to `/v2/images/$IM
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import image_actions_api
-from openapi_client.model.action import Action
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import image_actions_api
+from digitalocean_client.model.action import Action
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -39,12 +39,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = image_actions_api.ImageActionsApi(api_client)
     image_id = 62137902 # int | A unique number that can be used to identify and reference a specific image.
@@ -55,7 +55,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Action
         api_response = api_instance.get_image_action(image_id, action_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImageActionsApi->get_image_action: %s\n" % e)
 ```
 
@@ -107,13 +107,13 @@ To retrieve all actions that have been executed on an image, send a GET request 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import image_actions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import image_actions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -123,12 +123,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = image_actions_api.ImageActionsApi(api_client)
     image_id = 62137902 # int | A unique number that can be used to identify and reference a specific image.
@@ -138,7 +138,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Actions for an Image
         api_response = api_instance.list_image_actions(image_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImageActionsApi->list_image_actions: %s\n" % e)
 ```
 
@@ -189,15 +189,15 @@ The following actions are available on an Image.  ## Convert an Image to a Snaps
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import image_actions_api
-from openapi_client.model.action import Action
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import image_actions_api
+from digitalocean_client.model.action import Action
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -207,12 +207,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = image_actions_api.ImageActionsApi(api_client)
     image_id = 62137902 # int | A unique number that can be used to identify and reference a specific image.
@@ -223,7 +223,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate an Image Action
         api_response = api_instance.post_image_action(image_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImageActionsApi->post_image_action: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -232,7 +232,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Initiate an Image Action
         api_response = api_instance.post_image_action(image_id, unknown_base_type=unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImageActionsApi->post_image_action: %s\n" % e)
 ```
 

--- a/docs/ImagesApi.md
+++ b/docs/ImagesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ImagesApi
+# digitalocean_client.ImagesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -24,14 +24,14 @@ To create a new custom image, send a POST request to /v2/images. The body must c
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import images_api
-from openapi_client.model.image_new_custom import ImageNewCustom
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import images_api
+from digitalocean_client.model.image_new_custom import ImageNewCustom
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -41,12 +41,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = images_api.ImagesApi(api_client)
     image_new_custom = ImageNewCustom() # ImageNewCustom | 
@@ -56,7 +56,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a Custom Image
         api_response = api_instance.create_custom_image(image_new_custom)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImagesApi->create_custom_image: %s\n" % e)
 ```
 
@@ -106,13 +106,13 @@ To delete a snapshot or custom image, send a `DELETE` request to `/v2/images/$IM
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import images_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import images_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -122,12 +122,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = images_api.ImagesApi(api_client)
     image_id = 62137902 # int | A unique number that can be used to identify and reference a specific image.
@@ -136,7 +136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete an Image
         api_instance.delete_image(image_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImagesApi->delete_image: %s\n" % e)
 ```
 
@@ -187,14 +187,14 @@ To retrieve information about an image, send a `GET` request to `/v2/images/$IDE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import images_api
-from openapi_client.model.inline_response2004 import InlineResponse2004
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import images_api
+from digitalocean_client.model.inline_response2004 import InlineResponse2004
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -204,12 +204,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = images_api.ImagesApi(api_client)
     image_id = None # bool, date, datetime, dict, float, int, list, str, none_type | A unique number (id) or string (slug) used to identify and reference a specific image.  **Public** images can be identified by image `id` or `slug`.  **Private** images *must* be identified by image `id`. 
@@ -219,7 +219,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Image
         api_response = api_instance.get_image(image_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImagesApi->get_image: %s\n" % e)
 ```
 
@@ -270,13 +270,13 @@ To list all of the images available on your account, send a GET request to /v2/i
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import images_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import images_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -286,12 +286,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = images_api.ImagesApi(api_client)
     type = "distribution" # str | Filters results based on image type which can be either `application` or `distribution`. (optional)
@@ -306,7 +306,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Images
         api_response = api_instance.get_images_list(type=type, private=private, tag_name=tag_name, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImagesApi->get_images_list: %s\n" % e)
 ```
 
@@ -360,15 +360,15 @@ To update an image, send a `PUT` request to `/v2/images/$IMAGE_ID`. Set the `nam
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import images_api
-from openapi_client.model.inline_response2004 import InlineResponse2004
-from openapi_client.model.error import Error
-from openapi_client.model.image_update import ImageUpdate
+import digitalocean_client
+from digitalocean_client.api import images_api
+from digitalocean_client.model.inline_response2004 import InlineResponse2004
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.image_update import ImageUpdate
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -378,12 +378,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = images_api.ImagesApi(api_client)
     image_id = 62137902 # int | A unique number that can be used to identify and reference a specific image.
@@ -398,7 +398,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update an Image
         api_response = api_instance.update_image(image_id, image_update)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ImagesApi->update_image: %s\n" % e)
 ```
 

--- a/docs/KubernetesApi.md
+++ b/docs/KubernetesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.KubernetesApi
+# digitalocean_client.KubernetesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -44,14 +44,14 @@ To add an additional node pool to a Kubernetes clusters, send a POST request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.kubernetes_node_pool import KubernetesNodePool
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.kubernetes_node_pool import KubernetesNodePool
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -61,12 +61,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -77,7 +77,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Add a Node Pool to a Kubernetes Cluster
         api_response = api_instance.add_kubernetes_node_pool(cluster_id, kubernetes_node_pool)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->add_kubernetes_node_pool: %s\n" % e)
 ```
 
@@ -129,14 +129,14 @@ To integrate the container registry with Kubernetes clusters, send a POST reques
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.cluster_registries import ClusterRegistries
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.cluster_registries import ClusterRegistries
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -146,12 +146,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_registries = ClusterRegistries(
@@ -163,7 +163,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Container Registry to Kubernetes Clusters
         api_instance.add_registry(cluster_registries=cluster_registries)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->add_registry: %s\n" % e)
 ```
 
@@ -213,14 +213,14 @@ To create a new Kubernetes cluster, send a POST request to `/v2/kubernetes/clust
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.cluster import Cluster
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.cluster import Cluster
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -230,12 +230,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster = Cluster(
@@ -261,7 +261,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Kubernetes Cluster
         api_response = api_instance.create_kubernetes_cluster(cluster)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->create_kubernetes_cluster: %s\n" % e)
 ```
 
@@ -311,13 +311,13 @@ To delete a Kubernetes cluster and all services deployed to it, send a DELETE re
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -327,12 +327,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -341,7 +341,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Kubernetes Cluster
         api_instance.delete_kubernetes_cluster(cluster_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->delete_kubernetes_cluster: %s\n" % e)
 ```
 
@@ -392,13 +392,13 @@ To delete a single node in a pool, send a DELETE request to `/v2/kubernetes/clus
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -408,12 +408,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -426,7 +426,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Node in a Kubernetes Cluster
         api_instance.delete_kubernetes_node(cluster_id, node_pool_id, node_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->delete_kubernetes_node: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -434,7 +434,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Node in a Kubernetes Cluster
         api_instance.delete_kubernetes_node(cluster_id, node_pool_id, node_id, skip_drain=skip_drain, replace=replace)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->delete_kubernetes_node: %s\n" % e)
 ```
 
@@ -489,13 +489,13 @@ To delete a node pool, send a DELETE request to `/v2/kubernetes/clusters/$K8S_CL
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -505,12 +505,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -520,7 +520,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Node Pool in a Kubernetes Cluster
         api_instance.delete_kubernetes_node_pool(cluster_id, node_pool_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->delete_kubernetes_node_pool: %s\n" % e)
 ```
 
@@ -572,13 +572,13 @@ To delete a Kubernetes cluster with all of its associated resources, send a DELE
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -588,12 +588,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -602,7 +602,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Cluster and All of its Associated Resources (Dangerous)
         api_instance.destroy_kubernetes_associated_resources_dangerous(cluster_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->destroy_kubernetes_associated_resources_dangerous: %s\n" % e)
 ```
 
@@ -653,14 +653,14 @@ To delete a Kubernetes cluster along with a subset of its associated resources, 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.destroy_associated_kubernetes_resources import DestroyAssociatedKubernetesResources
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.destroy_associated_kubernetes_resources import DestroyAssociatedKubernetesResources
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -670,12 +670,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -689,7 +689,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Selectively Delete a Cluster and its Associated Resources
         api_instance.destroy_kubernetes_associated_resources_selective(cluster_id, destroy_associated_kubernetes_resources)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->destroy_kubernetes_associated_resources_selective: %s\n" % e)
 ```
 
@@ -741,14 +741,14 @@ To determine whether a cluster can be upgraded, and the versions to which it can
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.inline_response2005 import InlineResponse2005
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.inline_response2005 import InlineResponse2005
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -758,12 +758,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -773,7 +773,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Available Upgrades for an Existing Kubernetes Cluster
         api_response = api_instance.get_available_upgrades(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_available_upgrades: %s\n" % e)
 ```
 
@@ -824,14 +824,14 @@ To show information the user associated with a Kubernetes cluster, send a GET re
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.user import User
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.user import User
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -841,12 +841,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -856,7 +856,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve User Information for a Kubernetes Cluster
         api_response = api_instance.get_cluster_user(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_cluster_user: %s\n" % e)
 ```
 
@@ -907,14 +907,14 @@ To request clusterlint diagnostics for your cluster, send a GET request to `/v2/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.clusterlint_results import ClusterlintResults
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.clusterlint_results import ClusterlintResults
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -924,12 +924,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -940,7 +940,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Fetch Clusterlint Diagnostics for a Kubernetes Cluster
         api_response = api_instance.get_clusterlint_results(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_clusterlint_results: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -949,7 +949,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Fetch Clusterlint Diagnostics for a Kubernetes Cluster
         api_response = api_instance.get_clusterlint_results(cluster_id, run_id=run_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_clusterlint_results: %s\n" % e)
 ```
 
@@ -1001,14 +1001,14 @@ This endpoint returns a JSON object . It can be used to programmatically constru
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.credentials import Credentials
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.credentials import Credentials
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1018,12 +1018,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1034,7 +1034,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Credentials for a Kubernetes Cluster
         api_response = api_instance.get_credentials(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_credentials: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1043,7 +1043,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve Credentials for a Kubernetes Cluster
         api_response = api_instance.get_credentials(cluster_id, expiry_seconds=expiry_seconds)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_credentials: %s\n" % e)
 ```
 
@@ -1095,13 +1095,13 @@ This endpoint returns a kubeconfig file in YAML format. It can be used to connec
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1111,12 +1111,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1127,7 +1127,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the kubeconfig for a Kubernetes Cluster
         api_response = api_instance.get_kubeconfig(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_kubeconfig: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1136,7 +1136,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the kubeconfig for a Kubernetes Cluster
         api_response = api_instance.get_kubeconfig(cluster_id, expiry_seconds=expiry_seconds)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_kubeconfig: %s\n" % e)
 ```
 
@@ -1188,13 +1188,13 @@ To show information about an existing Kubernetes cluster, send a GET request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1204,12 +1204,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1219,7 +1219,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Kubernetes Cluster
         api_response = api_instance.get_kubernetes_cluster(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_kubernetes_cluster: %s\n" % e)
 ```
 
@@ -1270,13 +1270,13 @@ To show information about a specific node pool in a Kubernetes cluster, send a G
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1286,12 +1286,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1302,7 +1302,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve a Node Pool for a Kubernetes Cluster
         api_response = api_instance.get_node_pool(cluster_id, node_pool_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->get_node_pool: %s\n" % e)
 ```
 
@@ -1354,13 +1354,13 @@ To list all of the Kubernetes clusters on your account, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1370,12 +1370,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -1387,7 +1387,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Kubernetes Clusters
         api_response = api_instance.list_all_kubernetes_clusters(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->list_all_kubernetes_clusters: %s\n" % e)
 ```
 
@@ -1438,14 +1438,14 @@ To list the associated billable resources that can be destroyed along with a clu
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.associated_kubernetes_resources import AssociatedKubernetesResources
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.associated_kubernetes_resources import AssociatedKubernetesResources
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1455,12 +1455,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1470,7 +1470,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Associated Resources for Cluster Deletion
         api_response = api_instance.list_kubernetes_associated_resources(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->list_kubernetes_associated_resources: %s\n" % e)
 ```
 
@@ -1521,14 +1521,14 @@ To list the versions of Kubernetes available for use, the regions that support K
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.kubernetes_options import KubernetesOptions
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.kubernetes_options import KubernetesOptions
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1538,12 +1538,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
 
@@ -1552,7 +1552,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Available Regions, Node Sizes, and Versions of Kubernetes
         api_response = api_instance.list_kubernetes_options()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->list_kubernetes_options: %s\n" % e)
 ```
 
@@ -1600,13 +1600,13 @@ To list all of the node pools in a Kubernetes clusters, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1616,12 +1616,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1631,7 +1631,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Node Pools in a Kubernetes Clusters
         api_response = api_instance.list_node_pools(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->list_node_pools: %s\n" % e)
 ```
 
@@ -1682,14 +1682,14 @@ The endpoint has been deprecated. Please use the DELETE `/v2/kubernetes/clusters
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1699,12 +1699,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1715,7 +1715,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Recycle a Kubernetes Node Pool
         api_instance.recycle_kubernetes_node_pool(cluster_id, node_pool_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->recycle_kubernetes_node_pool: %s\n" % e)
 ```
 
@@ -1768,14 +1768,14 @@ To remove the container registry from Kubernetes clusters, send a DELETE request
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.cluster_registries import ClusterRegistries
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.cluster_registries import ClusterRegistries
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1785,12 +1785,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_registries = ClusterRegistries(
@@ -1802,7 +1802,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Container Registry from Kubernetes Clusters
         api_instance.remove_registry(cluster_registries=cluster_registries)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->remove_registry: %s\n" % e)
 ```
 
@@ -1852,14 +1852,14 @@ Clusterlint helps operators conform to Kubernetes best practices around resource
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.clusterlint_request import ClusterlintRequest
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.clusterlint_request import ClusterlintRequest
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1869,12 +1869,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1890,7 +1890,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Run Clusterlint Checks on a Kubernetes Cluster
         api_response = api_instance.run_clusterlint(cluster_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->run_clusterlint: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -1899,7 +1899,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Run Clusterlint Checks on a Kubernetes Cluster
         api_response = api_instance.run_clusterlint(cluster_id, clusterlint_request=clusterlint_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->run_clusterlint: %s\n" % e)
 ```
 
@@ -1951,14 +1951,14 @@ To update a Kubernetes cluster, send a PUT request to `/v2/kubernetes/clusters/$
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.error import Error
-from openapi_client.model.cluster_update import ClusterUpdate
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.cluster_update import ClusterUpdate
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1968,12 +1968,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -1993,7 +1993,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Kubernetes Cluster
         api_response = api_instance.update_kubernetes_cluster(cluster_id, cluster_update)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->update_kubernetes_cluster: %s\n" % e)
 ```
 
@@ -2045,14 +2045,14 @@ To update the name of a node pool, edit the tags applied to it, or adjust its nu
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.kubernetes_node_pool_update import KubernetesNodePoolUpdate
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.kubernetes_node_pool_update import KubernetesNodePoolUpdate
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2062,12 +2062,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -2079,7 +2079,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Node Pool in a Kubernetes Cluster
         api_response = api_instance.update_kubernetes_node_pool(cluster_id, node_pool_id, kubernetes_node_pool_update)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->update_kubernetes_node_pool: %s\n" % e)
 ```
 
@@ -2132,14 +2132,14 @@ To immediately upgrade a Kubernetes cluster to a newer patch release of Kubernet
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import kubernetes_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import kubernetes_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -2149,12 +2149,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = kubernetes_api.KubernetesApi(api_client)
     cluster_id = "bd5f5959-5e1e-4205-a714-a914373942af" # str | A unique ID that can be used to reference a Kubernetes cluster.
@@ -2164,7 +2164,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Upgrade a Kubernetes Cluster
         api_instance.upgrade_kubernetes_cluster(cluster_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling KubernetesApi->upgrade_kubernetes_cluster: %s\n" % e)
 ```
 

--- a/docs/LoadBalancersApi.md
+++ b/docs/LoadBalancersApi.md
@@ -1,4 +1,4 @@
-# openapi_client.LoadBalancersApi
+# digitalocean_client.LoadBalancersApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -28,14 +28,14 @@ To assign a Droplet to a load balancer instance, send a POST request to `/v2/loa
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -45,12 +45,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -60,7 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Droplets to a Load Balancer
         api_instance.add_load_balancer_droplets(lb_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->add_load_balancer_droplets: %s\n" % e)
 ```
 
@@ -112,14 +112,14 @@ To add an additional forwarding rule to a load balancer instance, send a POST re
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -129,12 +129,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -144,7 +144,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Add Forwarding Rules to a Load Balancer
         api_instance.add_load_balancer_forwarding_rules(lb_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->add_load_balancer_forwarding_rules: %s\n" % e)
 ```
 
@@ -196,14 +196,14 @@ To create a new load balancer instance, send a POST request to `/v2/load_balance
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.error import Error
-from openapi_client.model.load_balancer_create import LoadBalancerCreate
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.load_balancer_create import LoadBalancerCreate
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -213,12 +213,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     load_balancer_create = LoadBalancerCreate(None) # LoadBalancerCreate | 
@@ -228,7 +228,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Load Balancer
         api_response = api_instance.create_load_balancer(load_balancer_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->create_load_balancer: %s\n" % e)
 ```
 
@@ -278,13 +278,13 @@ To delete a load balancer instance, disassociating any Droplets assigned to it a
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -294,12 +294,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -308,7 +308,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Load Balancer
         api_instance.delete_load_balancer(lb_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->delete_load_balancer: %s\n" % e)
 ```
 
@@ -359,13 +359,13 @@ To show information about a load balancer instance, send a GET request to `/v2/l
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -375,12 +375,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -390,7 +390,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Load Balancer
         api_response = api_instance.get_load_balancer(lb_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->get_load_balancer: %s\n" % e)
 ```
 
@@ -441,13 +441,13 @@ To list all of the load balancer instances on your account, send a GET request t
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -457,12 +457,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -474,7 +474,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Load Balancers
         api_response = api_instance.list_all_load_balancers(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->list_all_load_balancers: %s\n" % e)
 ```
 
@@ -525,14 +525,14 @@ To remove a Droplet from a load balancer instance, send a DELETE request to `/v2
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -542,12 +542,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -557,7 +557,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Droplets from a Load Balancer
         api_instance.remove_load_balancer_droplets(lb_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->remove_load_balancer_droplets: %s\n" % e)
 ```
 
@@ -609,14 +609,14 @@ To remove forwarding rules from a load balancer instance, send a DELETE request 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -626,12 +626,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -641,7 +641,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Remove Forwarding Rules from a Load Balancer
         api_instance.remove_load_balancer_forwarding_rules(lb_id, unknown_base_type)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->remove_load_balancer_forwarding_rules: %s\n" % e)
 ```
 
@@ -693,14 +693,14 @@ To update a load balancer's settings, send a PUT request to `/v2/load_balancers/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import load_balancers_api
-from openapi_client.model.error import Error
-from openapi_client.model.load_balancer_create import LoadBalancerCreate
+import digitalocean_client
+from digitalocean_client.api import load_balancers_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.load_balancer_create import LoadBalancerCreate
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -710,12 +710,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = load_balancers_api.LoadBalancersApi(api_client)
     lb_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a load balancer.
@@ -726,7 +726,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Load Balancer
         api_response = api_instance.update_load_balancer(lb_id, load_balancer_create)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling LoadBalancersApi->update_load_balancer: %s\n" % e)
 ```
 

--- a/docs/MonitoringApi.md
+++ b/docs/MonitoringApi.md
@@ -1,4 +1,4 @@
-# openapi_client.MonitoringApi
+# digitalocean_client.MonitoringApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -35,15 +35,15 @@ To create a new alert, send a POST request to `/v2/monitoring/alerts`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.error import Error
-from openapi_client.model.alert_policy_request import AlertPolicyRequest
-from openapi_client.model.alert_policy import AlertPolicy
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.alert_policy_request import AlertPolicyRequest
+from digitalocean_client.model.alert_policy import AlertPolicy
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -53,12 +53,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     alert_policy_request = AlertPolicyRequest(
@@ -86,7 +86,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create Alert Policy
         api_response = api_instance.create_alert_policy(alert_policy_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->create_alert_policy: %s\n" % e)
 ```
 
@@ -136,13 +136,13 @@ To delete an alert policy, send a DELETE request to `/v2/monitoring/alerts/{aler
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -152,12 +152,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     alert_uuid = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for an alert policy.
@@ -166,7 +166,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete an Alert Policy
         api_instance.delete_alert_policy(alert_uuid)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->delete_alert_policy: %s\n" % e)
 ```
 
@@ -217,14 +217,14 @@ To retrieve a given alert policy, send a GET request to `/v2/monitoring/alerts/{
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.error import Error
-from openapi_client.model.alert_policy import AlertPolicy
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.alert_policy import AlertPolicy
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -234,12 +234,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     alert_uuid = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for an alert policy.
@@ -249,7 +249,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Alert Policy
         api_response = api_instance.get_alert_policy(alert_uuid)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_alert_policy: %s\n" % e)
 ```
 
@@ -300,14 +300,14 @@ To retrieve bandwidth metrics for a given Droplet, send a GET request to `/v2/mo
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -317,12 +317,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -336,7 +336,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Bandwidth Metrics
         api_response = api_instance.get_droplet_bandwidth_metrics(host_id, interface, direction, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_bandwidth_metrics: %s\n" % e)
 ```
 
@@ -390,14 +390,14 @@ To retrieve CPU metrics for a given droplet, send a GET request to `/v2/monitori
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -407,12 +407,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -424,7 +424,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet CPU Metrics
         api_response = api_instance.get_droplet_cpu_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_cpu_metrics: %s\n" % e)
 ```
 
@@ -476,14 +476,14 @@ To retrieve filesystem free metrics for a given droplet, send a GET request to `
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -493,12 +493,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -510,7 +510,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Filesystem Free Metrics
         api_response = api_instance.get_droplet_filesystem_free_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_filesystem_free_metrics: %s\n" % e)
 ```
 
@@ -562,14 +562,14 @@ To retrieve filesystem size metrics for a given droplet, send a GET request to `
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -579,12 +579,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -596,7 +596,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Filesystem Size Metrics
         api_response = api_instance.get_droplet_filesystem_size_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_filesystem_size_metrics: %s\n" % e)
 ```
 
@@ -648,14 +648,14 @@ To retrieve 15 minute load average metrics for a given droplet, send a GET reque
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -665,12 +665,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -682,7 +682,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Load15 Metrics
         api_response = api_instance.get_droplet_load15_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_load15_metrics: %s\n" % e)
 ```
 
@@ -734,14 +734,14 @@ To retrieve 1 minute load average metrics for a given droplet, send a GET reques
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -751,12 +751,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -768,7 +768,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Load1 Metrics
         api_response = api_instance.get_droplet_load1_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_load1_metrics: %s\n" % e)
 ```
 
@@ -820,14 +820,14 @@ To retrieve 5 minute load average metrics for a given droplet, send a GET reques
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -837,12 +837,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -854,7 +854,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Load5 Metrics
         api_response = api_instance.get_droplet_load5_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_load5_metrics: %s\n" % e)
 ```
 
@@ -906,14 +906,14 @@ To retrieve available memory metrics for a given droplet, send a GET request to 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -923,12 +923,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -940,7 +940,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Available Memory Metrics
         api_response = api_instance.get_droplet_memory_available_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_memory_available_metrics: %s\n" % e)
 ```
 
@@ -992,14 +992,14 @@ To retrieve cached memory metrics for a given droplet, send a GET request to `/v
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1009,12 +1009,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -1026,7 +1026,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Cached Memory Metrics
         api_response = api_instance.get_droplet_memory_cached_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_memory_cached_metrics: %s\n" % e)
 ```
 
@@ -1078,14 +1078,14 @@ To retrieve free memory metrics for a given droplet, send a GET request to `/v2/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1095,12 +1095,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -1112,7 +1112,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Free Memory Metrics
         api_response = api_instance.get_droplet_memory_free_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_memory_free_metrics: %s\n" % e)
 ```
 
@@ -1164,14 +1164,14 @@ To retrieve total memory metrics for a given droplet, send a GET request to `/v2
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.metrics import Metrics
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.metrics import Metrics
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1181,12 +1181,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     host_id = "17209102" # str | The droplet ID.
@@ -1198,7 +1198,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Get Droplet Total Memory Metrics
         api_response = api_instance.get_droplet_memory_total_metrics(host_id, start, end)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->get_droplet_memory_total_metrics: %s\n" % e)
 ```
 
@@ -1250,13 +1250,13 @@ Returns all alert policies that are configured for the given account. To List al
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1266,12 +1266,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -1283,7 +1283,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Alert Policies
         api_response = api_instance.list_alert_policies(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->list_alert_policies: %s\n" % e)
 ```
 
@@ -1334,15 +1334,15 @@ To update en existing policy, send a PUT request to `v2/monitoring/alerts/{alert
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import monitoring_api
-from openapi_client.model.error import Error
-from openapi_client.model.alert_policy_request import AlertPolicyRequest
-from openapi_client.model.alert_policy import AlertPolicy
+import digitalocean_client
+from digitalocean_client.api import monitoring_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.alert_policy_request import AlertPolicyRequest
+from digitalocean_client.model.alert_policy import AlertPolicy
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -1352,12 +1352,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = monitoring_api.MonitoringApi(api_client)
     alert_uuid = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for an alert policy.
@@ -1386,7 +1386,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update an Alert Policy
         api_response = api_instance.update_alert_policy(alert_uuid, alert_policy_request)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling MonitoringApi->update_alert_policy: %s\n" % e)
 ```
 

--- a/docs/ProjectResourcesApi.md
+++ b/docs/ProjectResourcesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ProjectResourcesApi
+# digitalocean_client.ProjectResourcesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -23,15 +23,15 @@ To assign resources to your default project, send a POST request to `/v2/project
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import project_resources_api
-from openapi_client.model.error import Error
-from openapi_client.model.project_assignment import ProjectAssignment
-from openapi_client.model.inline_response2006 import InlineResponse2006
+import digitalocean_client
+from digitalocean_client.api import project_resources_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.project_assignment import ProjectAssignment
+from digitalocean_client.model.inline_response2006 import InlineResponse2006
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -41,12 +41,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = project_resources_api.ProjectResourcesApi(api_client)
     project_assignment = ProjectAssignment(
@@ -60,7 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Assign Resources to Default Project
         api_response = api_instance.assign_default_project_resources(project_assignment)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectResourcesApi->assign_default_project_resources: %s\n" % e)
 ```
 
@@ -111,15 +111,15 @@ To assign resources to a project, send a POST request to `/v2/projects/$PROJECT_
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import project_resources_api
-from openapi_client.model.error import Error
-from openapi_client.model.project_assignment import ProjectAssignment
-from openapi_client.model.inline_response2006 import InlineResponse2006
+import digitalocean_client
+from digitalocean_client.api import project_resources_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.project_assignment import ProjectAssignment
+from digitalocean_client.model.inline_response2006 import InlineResponse2006
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -129,12 +129,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = project_resources_api.ProjectResourcesApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -149,7 +149,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Assign Resources to a Project
         api_response = api_instance.assign_project_resources(project_id, project_assignment)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectResourcesApi->assign_project_resources: %s\n" % e)
 ```
 
@@ -201,13 +201,13 @@ To list all your resources in your default project, send a GET request to `/v2/p
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import project_resources_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import project_resources_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -217,12 +217,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = project_resources_api.ProjectResourcesApi(api_client)
 
@@ -231,7 +231,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Default Project Resources
         api_response = api_instance.list_default_project_resources()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectResourcesApi->list_default_project_resources: %s\n" % e)
 ```
 
@@ -279,13 +279,13 @@ To list all your resources in a project, send a GET request to `/v2/projects/$PR
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import project_resources_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import project_resources_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -295,12 +295,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = project_resources_api.ProjectResourcesApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -310,7 +310,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List Project Resources
         api_response = api_instance.list_project_resources(project_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectResourcesApi->list_project_resources: %s\n" % e)
 ```
 

--- a/docs/ProjectsApi.md
+++ b/docs/ProjectsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.ProjectsApi
+# digitalocean_client.ProjectsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -28,14 +28,14 @@ To create a project, send a POST request to `/v2/projects`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -45,12 +45,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -60,7 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a Project
         api_response = api_instance.create_project(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->create_project: %s\n" % e)
 ```
 
@@ -110,13 +110,13 @@ To delete a project, send a DELETE request to `/v2/projects/$PROJECT_ID`. To be 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -126,12 +126,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -140,7 +140,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete an Existing Project
         api_instance.delete_project(project_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->delete_project: %s\n" % e)
 ```
 
@@ -192,13 +192,13 @@ To get your default project, send a GET request to `/v2/projects/default`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -208,12 +208,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
 
@@ -222,7 +222,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve the Default Project
         api_response = api_instance.get_default_project()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->get_default_project: %s\n" % e)
 ```
 
@@ -270,13 +270,13 @@ To get a project, send a GET request to `/v2/projects/$PROJECT_ID`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -286,12 +286,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -301,7 +301,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Project
         api_response = api_instance.get_project(project_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->get_project: %s\n" % e)
 ```
 
@@ -352,13 +352,13 @@ To list all your projects, send a GET request to `/v2/projects`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -368,12 +368,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
 
@@ -382,7 +382,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Projects
         api_response = api_instance.list_projects()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->list_projects: %s\n" % e)
 ```
 
@@ -429,14 +429,14 @@ To update only specific attributes of a project, send a PATCH request to `/v2/pr
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
-from openapi_client.model.project import Project
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.project import Project
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -446,12 +446,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     project = Project(None) # Project | 
@@ -461,7 +461,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Patch the Default Project
         api_response = api_instance.patch_default_project(project)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->patch_default_project: %s\n" % e)
 ```
 
@@ -512,14 +512,14 @@ To update only specific attributes of a project, send a PATCH request to `/v2/pr
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.error import Error
-from openapi_client.model.project import Project
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.project import Project
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -529,12 +529,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -545,7 +545,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Patch a Project
         api_response = api_instance.patch_project(project_id, project)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->patch_project: %s\n" % e)
 ```
 
@@ -597,14 +597,14 @@ To update a project, send a PUT request to `/v2/projects/default`. All of the fo
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -614,12 +614,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     unknown_base_type = None # UNKNOWN_BASE_TYPE | 
@@ -629,7 +629,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update the Default Project
         api_response = api_instance.update_default_project(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->update_default_project: %s\n" % e)
 ```
 
@@ -680,14 +680,14 @@ To update a project, send a PUT request to `/v2/projects/$PROJECT_ID`. All of th
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import projects_api
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import projects_api
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -697,12 +697,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = projects_api.ProjectsApi(api_client)
     project_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a project.
@@ -713,7 +713,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a Project
         api_response = api_instance.update_project(project_id, unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling ProjectsApi->update_project: %s\n" % e)
 ```
 

--- a/docs/RegionsApi.md
+++ b/docs/RegionsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.RegionsApi
+# digitalocean_client.RegionsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -20,13 +20,13 @@ To list all of the regions that are available, send a GET request to `/v2/region
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import regions_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import regions_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -36,12 +36,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = regions_api.RegionsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -53,7 +53,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Data Center Regions
         api_response = api_instance.list_all_regions(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling RegionsApi->list_all_regions: %s\n" % e)
 ```
 

--- a/docs/SSHKeysApi.md
+++ b/docs/SSHKeysApi.md
@@ -1,4 +1,4 @@
-# openapi_client.SSHKeysApi
+# digitalocean_client.SSHKeysApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -24,14 +24,14 @@ To add a new SSH public key to your DigitalOcean account, send a POST request to
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import ssh_keys_api
-from openapi_client.model.ssh_key import SshKey
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import ssh_keys_api
+from digitalocean_client.model.ssh_key import SshKey
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -41,12 +41,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ssh_keys_api.SSHKeysApi(api_client)
     ssh_key = SshKey(
@@ -59,7 +59,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New SSH Key
         api_response = api_instance.create_ssh_key(ssh_key)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SSHKeysApi->create_ssh_key: %s\n" % e)
 ```
 
@@ -109,13 +109,13 @@ To destroy a public SSH key that you have in your account, send a DELETE request
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import ssh_keys_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import ssh_keys_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -125,12 +125,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ssh_keys_api.SSHKeysApi(api_client)
     ssh_key_identifier = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID or the fingerprint of an existing SSH key.
@@ -139,7 +139,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete an SSH Key
         api_instance.destroy_ssh_key(ssh_key_identifier)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SSHKeysApi->destroy_ssh_key: %s\n" % e)
 ```
 
@@ -190,13 +190,13 @@ To get information about a key, send a GET request to `/v2/account/keys/$KEY_ID`
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import ssh_keys_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import ssh_keys_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -206,12 +206,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ssh_keys_api.SSHKeysApi(api_client)
     ssh_key_identifier = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID or the fingerprint of an existing SSH key.
@@ -221,7 +221,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing SSH Key
         api_response = api_instance.get_ssh_key(ssh_key_identifier)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SSHKeysApi->get_ssh_key: %s\n" % e)
 ```
 
@@ -272,13 +272,13 @@ To list all of the keys in your account, send a GET request to `/v2/account/keys
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import ssh_keys_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import ssh_keys_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -288,12 +288,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ssh_keys_api.SSHKeysApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -305,7 +305,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All SSH Keys
         api_response = api_instance.list_all_keys(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SSHKeysApi->list_all_keys: %s\n" % e)
 ```
 
@@ -356,14 +356,14 @@ To update the name of an SSH key, send a PUT request to either `/v2/account/keys
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import ssh_keys_api
-from openapi_client.model.inline_object import InlineObject
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import ssh_keys_api
+from digitalocean_client.model.inline_object import InlineObject
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -373,12 +373,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = ssh_keys_api.SSHKeysApi(api_client)
     ssh_key_identifier = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID or the fingerprint of an existing SSH key.
@@ -391,7 +391,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update an SSH Key's Name
         api_response = api_instance.update_ssh_key(ssh_key_identifier, inline_object)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SSHKeysApi->update_ssh_key: %s\n" % e)
 ```
 

--- a/docs/SizesApi.md
+++ b/docs/SizesApi.md
@@ -1,4 +1,4 @@
-# openapi_client.SizesApi
+# digitalocean_client.SizesApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -20,13 +20,13 @@ To list all of available Droplet sizes, send a GET request to `/v2/sizes`. The r
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import sizes_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import sizes_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -36,12 +36,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = sizes_api.SizesApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -53,7 +53,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Droplet Sizes
         api_response = api_instance.list_all_sizes(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SizesApi->list_all_sizes: %s\n" % e)
 ```
 

--- a/docs/SnapshotsApi.md
+++ b/docs/SnapshotsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.SnapshotsApi
+# digitalocean_client.SnapshotsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -22,13 +22,13 @@ Both Droplet and volume snapshots are managed through the `/v2/snapshots/` endpo
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import snapshots_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import snapshots_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -38,12 +38,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = snapshots_api.SnapshotsApi(api_client)
     snapshot_id = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID of an existing snapshot. This will be an integer for a Droplet snapshot or a string for a volume snapshot.
@@ -52,7 +52,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Snapshot
         api_instance.delete_snapshot(snapshot_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SnapshotsApi->delete_snapshot: %s\n" % e)
 ```
 
@@ -103,13 +103,13 @@ To retrieve information about a snapshot, send a GET request to `/v2/snapshots/$
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import snapshots_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import snapshots_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -119,12 +119,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = snapshots_api.SnapshotsApi(api_client)
     snapshot_id = None # bool, date, datetime, dict, float, int, list, str, none_type | Either the ID of an existing snapshot. This will be an integer for a Droplet snapshot or a string for a volume snapshot.
@@ -134,7 +134,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing Snapshot
         api_response = api_instance.get_snapshot(snapshot_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SnapshotsApi->get_snapshot: %s\n" % e)
 ```
 
@@ -185,13 +185,13 @@ To list all of the snapshots available on your account, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import snapshots_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import snapshots_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -201,12 +201,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = snapshots_api.SnapshotsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -219,7 +219,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Snapshots
         api_response = api_instance.list_all_snapshots(per_page=per_page, page=page, resource_type=resource_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling SnapshotsApi->list_all_snapshots: %s\n" % e)
 ```
 

--- a/docs/TagsApi.md
+++ b/docs/TagsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.TagsApi
+# digitalocean_client.TagsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -25,15 +25,15 @@ To create a tag you can send a POST request to `/v2/tags` with a `name` attribut
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.tag import Tag
-from openapi_client.model.error import Error
-from openapi_client.model.error_with_root_causes import ErrorWithRootCauses
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.tag import Tag
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.error_with_root_causes import ErrorWithRootCauses
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -43,12 +43,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
     tag = Tag(
@@ -60,7 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New Tag
         api_response = api_instance.create_new_tag(tag)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->create_new_tag: %s\n" % e)
 ```
 
@@ -111,13 +111,13 @@ A tag can be deleted by sending a `DELETE` request to `/v2/tags/$TAG_NAME`. Dele
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -127,12 +127,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
     tag_id = "awesome" # str | The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores. There is a limit of 255 characters per tag.
@@ -141,7 +141,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a Tag
         api_instance.delete_tag(tag_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->delete_tag: %s\n" % e)
 ```
 
@@ -192,14 +192,14 @@ To retrieve an individual tag, you can send a `GET` request to `/v2/tags/$TAG_NA
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.error import Error
-from openapi_client.model.inline_response20010 import InlineResponse20010
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.error import Error
+from digitalocean_client.model.inline_response20010 import InlineResponse20010
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -209,12 +209,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
     tag_id = "awesome" # str | The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores. There is a limit of 255 characters per tag.
@@ -224,7 +224,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve a Tag
         api_response = api_instance.get_tag(tag_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->get_tag: %s\n" % e)
 ```
 
@@ -275,13 +275,13 @@ To list all of your tags, you can send a GET request to `/v2/tags`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -291,12 +291,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
 
@@ -305,7 +305,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All Tags
         api_response = api_instance.list_all_tags()
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->list_all_tags: %s\n" % e)
 ```
 
@@ -352,14 +352,14 @@ Resources can be tagged by sending a POST request to `/v2/tags/$TAG_NAME/resourc
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.tag_resource import TagResource
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.tag_resource import TagResource
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -369,12 +369,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
     tag_id = "awesome" # str | The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores. There is a limit of 255 characters per tag.
@@ -386,7 +386,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Tag a Resource
         api_instance.tag_resource(tag_id, tag_resource)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->tag_resource: %s\n" % e)
 ```
 
@@ -438,14 +438,14 @@ Resources can be tagged by sending a DELETE request to `/v2/tags/$TAG_NAME/resou
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import tags_api
-from openapi_client.model.tag_resource import TagResource
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import tags_api
+from digitalocean_client.model.tag_resource import TagResource
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -455,12 +455,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = tags_api.TagsApi(api_client)
     tag_id = "awesome" # str | The name of the tag. Tags may contain letters, numbers, colons, dashes, and underscores. There is a limit of 255 characters per tag.
@@ -472,7 +472,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Untag a Resource
         api_instance.untag_resource(tag_id, tag_resource)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling TagsApi->untag_resource: %s\n" % e)
 ```
 

--- a/docs/VPCsApi.md
+++ b/docs/VPCsApi.md
@@ -1,4 +1,4 @@
-# openapi_client.VPCsApi
+# digitalocean_client.VPCsApi
 
 All URIs are relative to *https://api.digitalocean.com*
 
@@ -26,15 +26,15 @@ To create a VPC, send a POST request to `/v2/vpcs` specifying the attributes in 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.inline_response2016 import InlineResponse2016
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.inline_response2016 import InlineResponse2016
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -44,12 +44,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     unknown_base_type = {} # UNKNOWN_BASE_TYPE | 
@@ -59,7 +59,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Create a New VPC
         api_response = api_instance.create_vpc(unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->create_vpc: %s\n" % e)
 ```
 
@@ -109,13 +109,13 @@ To delete a VPC, send a DELETE request to `/v2/vpcs/$VPC_ID`. A 204 status code 
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -125,12 +125,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     vpc_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a VPC.
@@ -139,7 +139,7 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         # Delete a VPC
         api_instance.delete_vpc(vpc_id)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->delete_vpc: %s\n" % e)
 ```
 
@@ -190,14 +190,14 @@ To show information about an existing VPC, send a GET request to `/v2/vpcs/$VPC_
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.inline_response2016 import InlineResponse2016
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.inline_response2016 import InlineResponse2016
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -207,12 +207,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     vpc_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a VPC.
@@ -222,7 +222,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Retrieve an Existing VPC
         api_response = api_instance.get_vpc(vpc_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->get_vpc: %s\n" % e)
 ```
 
@@ -273,13 +273,13 @@ To list all of the resources that are members of a VPC, send a GET request to `/
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -289,12 +289,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     vpc_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a VPC.
@@ -307,7 +307,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List the Member Resources of a VPC
         api_response = api_instance.list_vpc_members(vpc_id)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->list_vpc_members: %s\n" % e)
 
     # example passing only required values which don't have defaults set
@@ -316,7 +316,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List the Member Resources of a VPC
         api_response = api_instance.list_vpc_members(vpc_id, resource_type=resource_type, per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->list_vpc_members: %s\n" % e)
 ```
 
@@ -370,13 +370,13 @@ To list all of the VPCs on your account, send a GET request to `/v2/vpcs`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -386,12 +386,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     per_page = 2 # int | Number of items returned per page (optional) if omitted the server will use the default value of 20
@@ -403,7 +403,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # List All VPCs
         api_response = api_instance.list_vpcs(per_page=per_page, page=page)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->list_vpcs: %s\n" % e)
 ```
 
@@ -455,15 +455,15 @@ To update a subset of information about a VPC, send a PATCH request to `/v2/vpcs
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.inline_response2016 import InlineResponse2016
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.inline_response2016 import InlineResponse2016
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -473,12 +473,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     vpc_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a VPC.
@@ -489,7 +489,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Partially Update a VPC
         api_response = api_instance.patch_vpc(vpc_id, unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->patch_vpc: %s\n" % e)
 ```
 
@@ -541,15 +541,15 @@ To update information about a VPC, send a PUT request to `/v2/vpcs/$VPC_ID`.
 
 ```python
 import time
-import openapi_client
-from openapi_client.api import vpcs_api
-from openapi_client.model.inline_response2016 import InlineResponse2016
-from openapi_client.model.unknownbasetype import UNKNOWNBASETYPE
-from openapi_client.model.error import Error
+import digitalocean_client
+from digitalocean_client.api import vpcs_api
+from digitalocean_client.model.inline_response2016 import InlineResponse2016
+from digitalocean_client.model.unknownbasetype import UNKNOWNBASETYPE
+from digitalocean_client.model.error import Error
 from pprint import pprint
 # Defining the host is optional and defaults to https://api.digitalocean.com
 # See configuration.py for a list of all supported configuration parameters.
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     host = "https://api.digitalocean.com"
 )
 
@@ -559,12 +559,12 @@ configuration = openapi_client.Configuration(
 # satisfies your auth use case.
 
 # Configure Bearer authorization: bearer_auth
-configuration = openapi_client.Configuration(
+configuration = digitalocean_client.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 
 # Enter a context with an instance of the API client
-with openapi_client.ApiClient(configuration) as api_client:
+with digitalocean_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vpcs_api.VPCsApi(api_client)
     vpc_id = "4de7ac8b-495b-4884-9a69-1050c6793cd6" # str | A unique identifier for a VPC.
@@ -575,7 +575,7 @@ with openapi_client.ApiClient(configuration) as api_client:
         # Update a VPC
         api_response = api_instance.update_vpc(vpc_id, unknown_base_type)
         pprint(api_response)
-    except openapi_client.ApiException as e:
+    except digitalocean_client.ApiException as e:
         print("Exception when calling VPCsApi->update_vpc: %s\n" % e)
 ```
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
 
 commands=
-   pytest --cov=openapi_client
+   pytest --cov=digitalocean_client


### PR DESCRIPTION
Commit `b89` renamed the package to `digitalocean_client`, but docs and `tox.init` weren't renamed as well.

This should fix #1 